### PR TITLE
Refactor settings datastore

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -85,7 +85,8 @@ module.exports = {
         {
             "files": "**/*.ts?(x)",
             "rules": {
-                "no-unused-vars": "off"
+                "no-unused-vars": "off",
+                "jsdoc/require-param": "off"
             }
         }
     ],

--- a/resources/js/admin.tsx
+++ b/resources/js/admin.tsx
@@ -1,10 +1,16 @@
 import React from 'react';
 
+import apiFetch from '@wordpress/api-fetch';
 import { createRoot } from '@wordpress/element';
 
 import SettingsPage from './components/settings-page';
 
 import '../css/admin.scss';
+
+// Configure apiFetch with nonce
+if (window.lolly?.nonce) {
+    apiFetch.use(apiFetch.createNonceMiddleware(window.lolly.nonce));
+}
 
 document.addEventListener('DOMContentLoaded', () => {
     const container = document.getElementById('lolly-settings');

--- a/resources/js/constants.ts
+++ b/resources/js/constants.ts
@@ -1,1 +1,8 @@
+import { WpRestApiError } from './types';
+
 export const SETTINGS_KEY = 'lolly_settings';
+
+export const DEFAULT_ERROR: WpRestApiError = {
+    code: 'unknown',
+    message: 'An unknown error occurred.',
+};

--- a/resources/js/global.d.ts
+++ b/resources/js/global.d.ts
@@ -1,0 +1,11 @@
+declare global {
+    interface Window {
+        lolly?: {
+            schema: any;
+            preloadedData: Record<string, any>;
+            nonce: string;
+        };
+    }
+}
+
+export {};

--- a/resources/js/settings/store/actions.ts
+++ b/resources/js/settings/store/actions.ts
@@ -1,0 +1,95 @@
+import apiFetch from '@wordpress/api-fetch';
+import { __ } from '@wordpress/i18n';
+
+import { SETTINGS_KEY } from '../../constants';
+import { Settings, WpRestApiError } from '../../types';
+import { isWpRestApiError } from '../../utils';
+
+import { Action, SettingsThunk } from './types';
+
+/**
+ * Edit a settings property.
+ *
+ * Intended for setting simple settings values, like the boolean
+ * flags.
+ */
+export function editSetting<K extends keyof Settings>(
+    property: K,
+    value: Settings[K]
+): Action {
+    return {
+        type: 'EDIT_SETTINGS_RECORD',
+        edits: {
+            [property]: value,
+        },
+    };
+}
+
+export const saveEditedSettings =
+    (): SettingsThunk =>
+    async ({ dispatch, select }) => {
+        const edits = select.getEdits();
+
+        if (Object.keys(edits).length === 0) {
+            dispatch({
+                type: 'SAVE_SETTINGS_RECORD_FAILED',
+                error: {
+                    code: 'lolly.save-settings-failed',
+                    message: __(
+                        'Failed to save Lolly settings, there are currently no edits.',
+                        'lolly'
+                    ),
+                },
+            });
+
+            return;
+        }
+
+        const combined = { ...select.getSettings(), ...edits };
+
+        try {
+            const response = await apiFetch<Record<string, unknown>>({
+                path: '/wp/v2/settings',
+                method: 'POST',
+                data: { [SETTINGS_KEY]: combined },
+            });
+
+            // We don't have to validate the server response here... do we?
+            const settings = response?.[SETTINGS_KEY] as Settings | undefined;
+
+            if (!settings) {
+                dispatch({
+                    type: 'SAVE_SETTINGS_RECORD_FAILED',
+                    error: {
+                        code: 'lolly.save-settings-failed',
+                        message: __(
+                            'Failed to save Lolly settings, the server response is missing the Lolly settings value.',
+                            'lolly'
+                        ),
+                    },
+                });
+
+                return;
+            }
+
+            dispatch({
+                type: 'SAVE_SETTINGS_RECORD_FINISHED',
+                settings,
+            });
+        } catch (e: unknown) {
+            const error: WpRestApiError = isWpRestApiError(e)
+                ? e
+                : {
+                      code: 'lolly.save-settings-failed',
+                      message: __(
+                          'Failed to save Lolly settings, an unknown error occurred.',
+                          'lolly'
+                      ),
+                  };
+
+            dispatch({
+                type: 'SAVE_SETTINGS_RECORD_FAILED',
+                error,
+            });
+        }
+    };

--- a/resources/js/settings/store/constants.ts
+++ b/resources/js/settings/store/constants.ts
@@ -1,0 +1,1 @@
+export const STORE_NAME = 'lolly/settings';

--- a/resources/js/settings/store/index.ts
+++ b/resources/js/settings/store/index.ts
@@ -1,0 +1,17 @@
+import { createReduxStore, register } from '@wordpress/data';
+
+import * as actions from './actions';
+import { STORE_NAME } from './constants';
+import reducer, { initializeDefaultState } from './reducer';
+import * as resolvers from './resolvers';
+import * as selectors from './selectors';
+
+export const store = createReduxStore(STORE_NAME, {
+    actions,
+    selectors,
+    reducer,
+    resolvers,
+    initialState: initializeDefaultState(),
+});
+
+register(store);

--- a/resources/js/settings/store/reducer.ts
+++ b/resources/js/settings/store/reducer.ts
@@ -1,0 +1,91 @@
+import { combineReducers } from '@wordpress/data';
+
+import type { SettingsState, State, Action, EditsState } from './types';
+
+function settings(state: SettingsState, action: Action): SettingsState {
+    switch (action.type) {
+        case 'FETCH_SETTINGS_START': {
+            return {
+                ...state,
+                isLoading: true,
+            };
+        }
+        case 'FETCH_SETTINGS_FINISHED': {
+            return {
+                ...state,
+                isLoading: false,
+                settings: action.settings,
+            };
+        }
+        case 'FETCH_SETTINGS_FAILED': {
+            return {
+                ...state,
+                isLoading: false,
+                error: action.error,
+            };
+        }
+        case 'SAVE_SETTINGS_RECORD_FINISHED': {
+            return {
+                ...state,
+                settings: action.settings,
+            };
+        }
+    }
+
+    return state;
+}
+
+function edits(state: EditsState, action: Action): EditsState {
+    switch (action.type) {
+        case 'EDIT_SETTINGS_RECORD': {
+            return {
+                ...state,
+                edits: {
+                    ...action.edits,
+                },
+            };
+        }
+        case 'SAVE_SETTINGS_RECORD_START': {
+            return {
+                ...state,
+                isSaving: true,
+                error: undefined,
+            };
+        }
+        case 'SAVE_SETTINGS_RECORD_FINISHED': {
+            return {
+                ...state,
+                edits: {},
+                isSaving: false,
+            };
+        }
+        case 'SAVE_SETTINGS_RECORD_FAILED': {
+            return {
+                ...state,
+                isSaving: false,
+                error: action.error,
+            };
+        }
+    }
+    return state;
+}
+
+export default combineReducers({
+    settings,
+    edits,
+});
+
+export function initializeDefaultState(): State {
+    return {
+        settings: {
+            settings: undefined,
+            isLoading: false,
+            error: undefined,
+        },
+        edits: {
+            edits: {},
+            isSaving: false,
+            error: undefined,
+        },
+    };
+}

--- a/resources/js/settings/store/reducer.ts
+++ b/resources/js/settings/store/reducer.ts
@@ -41,6 +41,7 @@ function edits(state: EditsState, action: Action): EditsState {
             return {
                 ...state,
                 edits: {
+                    ...state.edits,
                     ...action.edits,
                 },
             };

--- a/resources/js/settings/store/resolvers.ts
+++ b/resources/js/settings/store/resolvers.ts
@@ -1,0 +1,59 @@
+import apiFetch from '@wordpress/api-fetch';
+import { __ } from '@wordpress/i18n';
+
+import { SETTINGS_KEY } from '../../constants';
+import type { Settings } from '../../store/types';
+import { WpRestApiError } from '../../types';
+import { isWpRestApiError } from '../../utils';
+
+import type { SettingsThunk } from './types';
+
+export const getSettings =
+    (): SettingsThunk =>
+    async ({ dispatch }) => {
+        try {
+            const response = await apiFetch<Record<string, unknown>>({
+                path: '/wp/v2/settings',
+            });
+
+            // We don't have to validate the server response here... do we?
+            const settings = response?.[SETTINGS_KEY] as Settings | undefined;
+
+            if (!settings) {
+                dispatch({
+                    type: 'FETCH_SETTINGS_FAILED',
+                    error: {
+                        code: 'lolly.fetch-settings-failed',
+                        message: __(
+                            'Failed to fetch Lolly settings, the server response is missing the Lolly settings value.',
+                            'lolly'
+                        ),
+                    },
+                });
+
+                return;
+            }
+
+            dispatch({
+                type: 'FETCH_SETTINGS_FINISHED',
+                settings,
+            });
+        } catch (e: unknown) {
+            const error: WpRestApiError = isWpRestApiError(e)
+                ? e
+                : {
+                      code: 'lolly.fetch-settings-failed',
+                      message: __(
+                          'Failed to fetch Lolly settings, an unknown error occurred.',
+                          'lolly'
+                      ),
+                  };
+
+            // @todo Should we just throw the error here? We could catch it in an error boundary.
+            // Could be handy if we want to use `useSuspenseSelect`.
+            dispatch({
+                type: 'FETCH_SETTINGS_FAILED',
+                error,
+            });
+        }
+    };

--- a/resources/js/settings/store/resolvers.ts
+++ b/resources/js/settings/store/resolvers.ts
@@ -4,7 +4,7 @@ import { __ } from '@wordpress/i18n';
 import { SETTINGS_KEY } from '../../constants';
 import type { Settings } from '../../store/types';
 import { WpRestApiError } from '../../types';
-import { isWpRestApiError } from '../../utils';
+import { isWpRestApiError, forwardResolver } from '../../utils';
 
 import type { SettingsThunk } from './types';
 
@@ -57,3 +57,5 @@ export const getSettings =
             });
         }
     };
+
+export const getEditedSettings = forwardResolver('getSettings');

--- a/resources/js/settings/store/selectors.ts
+++ b/resources/js/settings/store/selectors.ts
@@ -1,0 +1,44 @@
+import type { Settings, WpRestApiError } from '../../types';
+
+import { State } from './types';
+
+export function getSettings(state: State): Settings | undefined {
+    return state.settings.settings;
+}
+
+export function isLoading(state: State): boolean {
+    return state.settings.isLoading;
+}
+
+export function isSaving(state: State): boolean {
+    return state.edits.isSaving;
+}
+
+export function getEdits(state: State): Partial<Settings> {
+    return state.edits.edits;
+}
+
+export function getEditsForProperty<K extends keyof Settings>(
+    state: State,
+    key: K
+): Settings[K] | undefined {
+    return state.edits.edits[key];
+}
+
+/**
+ * Whether the settings object has been edited.
+ */
+export function hasAnyEdits(state: State): boolean {
+    return Object.keys(state.edits.edits).length > 0;
+}
+
+/**
+ * Whether a specific property of the settings has been edited.
+ */
+export function hasEdits(state: State, key: keyof Settings): boolean {
+    return key in state.edits.edits;
+}
+
+export function getEditError(state: State): WpRestApiError | undefined {
+    return state.edits.error;
+}

--- a/resources/js/settings/store/selectors.ts
+++ b/resources/js/settings/store/selectors.ts
@@ -1,3 +1,5 @@
+import { createSelector } from '@wordpress/data';
+
 import type { Settings, WpRestApiError } from '../../types';
 
 import { State } from './types';
@@ -17,6 +19,18 @@ export function isSaving(state: State): boolean {
 export function getEdits(state: State): Partial<Settings> {
     return state.edits.edits;
 }
+
+export const getEditedSettings = createSelector(
+    (state: State): Settings | undefined => {
+        const settings = getSettings(state);
+        if (!settings) {
+            return undefined;
+        }
+        const edits = getEdits(state);
+        return { ...settings, ...edits };
+    },
+    (state: State) => [state.settings.settings, state.edits.edits]
+);
 
 export function getEditsForProperty<K extends keyof Settings>(
     state: State,

--- a/resources/js/settings/store/types.ts
+++ b/resources/js/settings/store/types.ts
@@ -1,0 +1,45 @@
+import {
+    StoreDescriptor,
+    ReduxStoreConfig,
+} from '@wordpress/data/build-types/redux-store';
+
+import { Settings } from '../../store/types';
+import type { Thunk } from '../../thunk';
+import { WpRestApiError } from '../../types';
+
+import * as actions from './actions';
+import * as selectors from './selectors';
+
+export type Action =
+    | { type: 'EDIT_SETTINGS_RECORD'; edits: Partial<Settings> }
+    | { type: 'SAVE_SETTINGS_RECORD_START' }
+    | { type: 'SAVE_SETTINGS_RECORD_FINISHED'; settings: Settings }
+    | { type: 'SAVE_SETTINGS_RECORD_FAILED'; error: WpRestApiError }
+    | { type: 'FETCH_SETTINGS_START' }
+    | { type: 'FETCH_SETTINGS_FINISHED'; settings: Settings }
+    | { type: 'FETCH_SETTINGS_FAILED'; error: WpRestApiError };
+
+export interface State {
+    settings: SettingsState;
+    edits: EditsState;
+}
+
+export interface SettingsState {
+    settings: Settings | undefined;
+    isLoading: boolean;
+    error: WpRestApiError | undefined;
+}
+
+export interface EditsState {
+    // @todo Since the value is edited through Monaco, perhaps this should be a
+    // string. I don't think we should JSON decode on every change to the Monaco
+    // value.
+    edits: Partial<Settings>;
+    isSaving: boolean;
+    error: WpRestApiError | undefined;
+}
+
+export type SettingsThunk = Thunk<
+    Action,
+    StoreDescriptor<ReduxStoreConfig<State, typeof actions, typeof selectors>>
+>;

--- a/resources/js/store/index.ts
+++ b/resources/js/store/index.ts
@@ -5,7 +5,7 @@ import reducer from './reducer';
 import resolvers from './resolvers';
 import selectors from './selectors';
 
-const STORE_NAME = 'lolly/settings';
+const STORE_NAME = 'lolly/settings-old';
 
 // @todo Resolvers should have matching selectors, and not combined with the actions.
 // Combine actions and resolvers

--- a/resources/js/thunk.ts
+++ b/resources/js/thunk.ts
@@ -1,0 +1,139 @@
+import {
+    invalidateResolution,
+    invalidateResolutionForStore,
+    invalidateResolutionForStoreSelector,
+} from '@wordpress/data/build-types/redux-store/metadata/actions';
+import type {
+    ActionCreatorsOf as BaseActionCreatorsOf,
+    AnyConfig,
+    CurriedSelectorsOf,
+    StoreDescriptor,
+} from '@wordpress/data/build-types/types';
+import type { Action } from 'redux';
+
+type InvalidateResolution = typeof invalidateResolution;
+type InvalidateResolutionForStore = typeof invalidateResolutionForStore;
+type InvalidateResolutionForStoreSelector =
+    typeof invalidateResolutionForStoreSelector;
+
+type InvalidateResolutionAction = ReturnType<InvalidateResolution>;
+type InvalidateResolutionForStoreAction =
+    ReturnType<InvalidateResolutionForStore>;
+type InvalidateResolutionForStoreSelectorAction =
+    ReturnType<InvalidateResolutionForStoreSelector>;
+
+/**
+ * The action creators for metadata actions.
+ */
+type MetadataActionCreators = {
+    invalidateResolution: InvalidateResolution;
+    invalidateResolutionForStore: InvalidateResolutionForStore;
+    invalidateResolutionForStoreSelector: InvalidateResolutionForStoreSelector;
+};
+
+/**
+ * Dispatchable metadata actions.
+ */
+type MetadataAction =
+    | InvalidateResolutionAction
+    | InvalidateResolutionForStoreAction
+    | InvalidateResolutionForStoreSelectorAction;
+
+export type PromisifiedSelectorsOf<S> =
+    S extends StoreDescriptor<AnyConfig>
+        ? {
+              [key in keyof CurriedSelectorsOf<S>]: PromisifySelectorOf<
+                  CurriedSelectorsOf<S>[key]
+              >;
+          }
+        : never;
+
+type PromisifySelectorOf<F extends Function> = F extends (
+    ...args: infer P
+) => infer R
+    ? (...args: P) => Promise<R>
+    : F;
+
+/**
+ * The action creators for a store descriptor.
+ *
+ * Also includes metadata actions creators.
+ */
+type ActionCreatorsOf<C extends AnyConfig> = BaseActionCreatorsOf<C> &
+    MetadataActionCreators;
+
+/**
+ * Dispatchable action creators for a store descriptor.
+ */
+export type RegistryDispatch<S extends string | StoreDescriptor<AnyConfig>> = (
+    storeNameOrDescriptor: S
+) => S extends StoreDescriptor<infer C> ? ActionCreatorsOf<C> : unknown;
+
+/**
+ * Selectors for a store descriptor.
+ */
+export type RegistrySelect<S extends string | StoreDescriptor<AnyConfig>> = (
+    storeNameOrDescriptor: S
+) => S extends StoreDescriptor<infer C> ? CurriedSelectorsOf<C> : unknown;
+
+/**
+ * Dispatch an action to the configured store.
+ */
+export type DispatchFunction<A extends Action> = (
+    action: A | MetadataAction
+) => void;
+
+/**
+ * A redux store registry.
+ */
+export type Registry = {
+    dispatch: <S extends string | StoreDescriptor<AnyConfig>>(
+        storeNameOrDescriptor: S
+    ) => S extends StoreDescriptor<infer C> ? ActionCreatorsOf<C> : unknown;
+    select: <S extends string | StoreDescriptor<AnyConfig>>(
+        storeNameOrDescriptor: S
+    ) => S extends StoreDescriptor<infer C> ? CurriedSelectorsOf<C> : unknown;
+};
+
+/**
+ * Thunk arguments.
+ */
+export type ThunkArgs<
+    A extends Action,
+    S extends StoreDescriptor<AnyConfig>,
+> = {
+    /**
+     * Dispatch an action to the store.
+     */
+    dispatch: (S extends StoreDescriptor<infer Config>
+        ? ActionCreatorsOf<Config>
+        : unknown) &
+        DispatchFunction<A>;
+
+    /**
+     * Selectors for the store.
+     */
+    select: CurriedSelectorsOf<S>;
+
+    /**
+     * Selectors for the store that return a promise awaiting their resolver.
+     */
+    resolveSelect: PromisifiedSelectorsOf<S>;
+
+    /**
+     * The store registry object.
+     */
+    registry: Registry;
+};
+
+/**
+ * Thunk.
+ */
+export type Thunk<
+    A extends Action,
+    S extends StoreDescriptor<AnyConfig>,
+    T extends unknown = void,
+> =
+    T extends Awaited<infer R>
+        ? (args: ThunkArgs<A, S>) => Promise<R>
+        : (args: ThunkArgs<A, S>) => T;

--- a/resources/js/types.ts
+++ b/resources/js/types.ts
@@ -1,0 +1,90 @@
+export interface RedactionItem {
+    type: string;
+    value: string;
+    remove?: boolean;
+}
+
+export interface PathRedaction {
+    path: string;
+    redactions: RedactionItem[];
+    glob?: boolean;
+}
+
+export interface HttpRedactionSet {
+    host: string;
+    paths: PathRedaction[];
+}
+
+export interface PathWhitelist {
+    path: string;
+    glob?: boolean;
+}
+
+export interface HttpWhitelistSet {
+    host: string;
+    paths: PathWhitelist[];
+    glob?: boolean;
+}
+
+export interface Settings {
+    enabled: boolean;
+    http_redactions_enabled: boolean;
+    http_whitelist_enabled: boolean;
+    wp_rest_logging_enabled: boolean;
+    wp_http_client_logging_enabled: boolean;
+    http_redactions: HttpRedactionSet[];
+    http_whitelist: HttpWhitelistSet[];
+}
+
+/**
+ * WordPress REST API error response format.
+ *
+ * Represents the JSON structure returned when a WP_Error is converted to
+ * a REST response. Oddly, this doesn't seem to exist in a `@wordpress`
+ * package.
+ */
+export interface WpRestApiError {
+    /**
+     * Error code (e.g., 'rest_invalid_param', 'rest_forbidden')
+     */
+    code: string;
+
+    /**
+     * Human-readable error message
+     */
+    message: string;
+
+    /**
+     * Additional error data
+     */
+    data?: {
+        /**
+         * HTTP status code
+         */
+        status: number;
+
+        /**
+         * Parameter-specific validation errors
+         */
+        params?: Record<string, string>;
+
+        /**
+         * Additional error details
+         */
+        details?: Record<string, unknown>;
+
+        /**
+         * Any other error data
+         */
+        [key: string]: unknown;
+    };
+
+    /**
+     * Additional error information (for multiple errors)
+     */
+    additional_errors?: Array<{
+        code: string;
+        message: string;
+        data?: unknown;
+    }>;
+}

--- a/resources/js/utils.ts
+++ b/resources/js/utils.ts
@@ -140,3 +140,17 @@ export function getErrorMessage(error: unknown): string {
 export function isObject(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null;
 }
+
+/**
+ * Higher-order function which forwards the resolution to another resolver with the same arguments.
+ *
+ * @param {string} resolverName forwarded resolver.
+ *
+ * @return {Function} Enhanced resolver.
+ */
+export function forwardResolver(resolverName: string): any {
+    return (...args: any) =>
+        async ({ resolveSelect }: { resolveSelect: any }) => {
+            await resolveSelect[resolverName](...args);
+        };
+}

--- a/resources/js/utils.ts
+++ b/resources/js/utils.ts
@@ -1,0 +1,142 @@
+import type { WpRestApiError } from './types';
+
+/**
+ * Type guard to check if an object is a WordPress REST API error response.
+ *
+ * @param error - The object to check
+ * @return True if the object matches the WPRestApiError structure
+ *
+ * @example
+ * try {
+ *   await apiFetch({ path: '/wp/v2/posts' });
+ * } catch (error) {
+ *   if (isWPRestApiError(error)) {
+ *     console.log('Error code:', error.code);
+ *     console.log('Error message:', error.message);
+ *   }
+ * }
+ */
+export function isWpRestApiError(error: unknown): error is WpRestApiError {
+    if (!isObject(error)) {
+        return false;
+    }
+
+    if (typeof error.code !== 'string' || typeof error.message !== 'string') {
+        return false;
+    }
+
+    if ('data' in error && isObject(error.data)) {
+        const data = error.data;
+
+        if ('status' in data && typeof data.status !== 'number') {
+            return false;
+        }
+
+        if ('params' in data && isObject(data.params)) {
+            const params = data.params;
+            for (const value of Object.values(params)) {
+                if (typeof value !== 'string') {
+                    return false;
+                }
+            }
+        }
+    }
+
+    if ('additional_errors' in error && error.additional_errors !== undefined) {
+        if (!Array.isArray(error.additional_errors)) {
+            return false;
+        }
+
+        // @todo Does each additional error have `data`?
+        for (const additionalError of error.additional_errors) {
+            if (
+                !isObject(additionalError) ||
+                typeof additionalError.code !== 'string' ||
+                typeof additionalError.message !== 'string'
+            ) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+/**
+ * Extracts user-friendly error messages from various error types.
+ * Returns an array of all error messages including additional errors.
+ *
+ * @param error - The error object
+ *
+ * @return An array of user-friendly error messages
+ *
+ * @example
+ * catch (error) {
+ *   const messages = getErrorMessages(error);
+ *   setErrors(messages);
+ * }
+ */
+export function getErrorMessages(error: unknown): string[] {
+    if (isWpRestApiError(error)) {
+        const messages: string[] = [];
+
+        // Add main error message
+        messages.push(error.message);
+
+        // Add parameter-specific errors
+        if (error.data?.params) {
+            const paramErrors = Object.entries(error.data.params).map(
+                ([key, value]) => `${key}: ${value}`
+            );
+            messages.push(...paramErrors);
+        }
+
+        // Add additional errors
+        if (error.additional_errors) {
+            const additionalMessages = error.additional_errors.map(
+                (err) => err.message
+            );
+            messages.push(...additionalMessages);
+        }
+
+        return messages;
+    }
+
+    if (error instanceof Error) {
+        return [error.message];
+    }
+
+    if (typeof error === 'string') {
+        return [error];
+    }
+
+    return ['An unknown error occurred'];
+}
+
+/**
+ * Extracts a single user-friendly error message from various error types.
+ * Joins multiple errors with commas.
+ *
+ * @param error - The error object
+ * @return A user-friendly error message
+ *
+ * @example
+ * catch (error) {
+ *   const message = getErrorMessage(error);
+ *   setError(message);
+ * }
+ */
+export function getErrorMessage(error: unknown): string {
+    return getErrorMessages(error).join(', ');
+}
+
+/**
+ * Object type guard.
+ *
+ * @param value
+ *
+ * @return Whether the value is an object.
+ */
+export function isObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}


### PR DESCRIPTION
Add a new version of the `lolly/settings` datastore. Uses a proper selector resolver pair for `getSettings`. Use patterns established by the `core/data` datastore.

Fixes #2