### PR TITLE
chore: add lint workflow for phpcs and phpstan

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,32 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.1
+
+      - name: Install Dependencies
+        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+
+      - name: Build Prefixed Dependencies
+        run: composer strauss
+
+      - name: Run PHPCS
+        run: composer lint
+
+      - name: Run PHPStan
+        run: composer analyse

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@
 /tests/Support/_generated/
 node_modules
 build
-.cache/
+.cache/*
+!.cache/.gitkeep
 .phpunit.result.cache
 .idea/
 .vscode/


### PR DESCRIPTION
CI now runs code style and static analysis checks on push to main and pull
requests. The workflow sets up PHP 8.1, installs dependencies, runs strauss
to build prefixed vendor classes, then executes phpcs and phpstan.

This runs separately from the slic-based test workflow, allowing faster
feedback on code quality issues.