### PR TITLE
chore: fix phpcs and phpstan errors for CI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
             "@php vendor/bin/phpstan analyse --memory-limit=4G --no-progress --no-interaction --ansi"
         ],
         "lint": [
-            "@php vendor/bin/phpcs -d memory_limit=2G -s"
+            "@php vendor/bin/phpcs -d memory_limit=2G -s -n"
         ],
         "lint:fix": [
             "@php vendor/bin/phpcbf -d memory_limit=2G"

--- a/index.php
+++ b/index.php
@@ -1,2 +1,8 @@
 <?php
-// Silence is golden.
+/**
+ * Silence is golden—
+ * Lolly logs what echoes past,
+ * stillness remains here.
+ *
+ * @package Lolly
+ */

--- a/lolly.php
+++ b/lolly.php
@@ -50,7 +50,7 @@ require __DIR__ . '/vendor/vendor-prefixed/autoload.php';
  * @package Lolly
  * @since 0.1.0
  */
-function lolly( string $abstract = null ): mixed {
+function lolly( ?string $abstract = null ): mixed {
     static $instance = null;
 
     if ( $instance === null ) {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -110,4 +110,9 @@
         <exclude-pattern>*/tests/*</exclude-pattern>
     </rule>
 
+    <!-- Allow $I variable in Codeception tests (convention). -->
+    <rule ref="WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase">
+        <exclude-pattern>*/tests/*</exclude-pattern>
+    </rule>
+
 </ruleset>

--- a/src/Lolly/Admin/SettingsPage.php
+++ b/src/Lolly/Admin/SettingsPage.php
@@ -19,9 +19,9 @@ class SettingsPage {
     public const MENU_SLUG = 'lolly-settings';
 
     /**
-     * Add admin menu page
+     * Add admin menu page.
      */
-    public function add_admin_menu() {
+    public function add_admin_menu(): void {
         add_options_page(
             __( 'Lolly Log Settings', 'lolly' ),
             __( 'Lolly Log', 'lolly' ),
@@ -32,9 +32,11 @@ class SettingsPage {
     }
 
     /**
-     * Enqueue admin scripts and styles
+     * Enqueue admin scripts and styles.
+     *
+     * @param string $hook The current admin page hook.
      */
-    public function enqueue_assets( $hook ) {
+    public function enqueue_assets( string $hook ): void {
         if ( 'settings_page_lolly-settings' !== $hook ) {
             return;
         }
@@ -92,7 +94,7 @@ class SettingsPage {
             []
         );
 
-        // Add inline script to configure apiFetch preloading middleware
+        // Add inline script to configure apiFetch preloading middleware.
         wp_add_inline_script(
             'wp-api-fetch',
             sprintf( 'wp.apiFetch.use( wp.apiFetch.createPreloadingMiddleware( %s ) );', wp_json_encode( $preload_data ) ),
@@ -111,9 +113,9 @@ class SettingsPage {
     }
 
     /**
-     * Render settings page
+     * Render settings page.
      */
-    public function render_settings_page() {
+    public function render_settings_page(): void {
         ?>
         <div class="wrap">
             <div id="lolly-settings"></div>

--- a/src/Lolly/Config/Config.php
+++ b/src/Lolly/Config/Config.php
@@ -14,8 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-// The logging redaction to merge into this system is
-// ["query" => ['user']]
+// The logging redaction to merge into this system is ["query" => ['user']].
 
 /**
  * Config class.
@@ -338,8 +337,8 @@ class Config implements RedactorConfig, WhitelistConfig {
                 'type'         => 'object',
                 'description'  => esc_html__( 'The Lolly logging configuration.', 'lolly' ),
                 // We don't need this right now, but I need to remember it is here.
-                // It will provide the lolly_settings value from the request.
-                // 'sanitize_callback' => [$this, 'sanitize_setting'],
+                // It will provide the lolly_settings value from the request:
+                // 'sanitize_callback' => [$this, 'sanitize_setting'].
                 'default'      => [
                     'version'                        => 1,
                     'enabled'                        => false,

--- a/src/Lolly/Lib.php
+++ b/src/Lolly/Lib.php
@@ -21,7 +21,9 @@ class Lib {
     public static function get_full_request_url(): string {
         global $wp;
         $protocol    = isset( $_SERVER['HTTPS'] ) && $_SERVER['HTTPS'] === 'on' ? 'https' : 'http';
+        // phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- Intentionally unsanitized for logging.
         $host        = $_SERVER['HTTP_HOST'] ?? null;
+        // phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- Intentionally unsanitized for logging.
         $request_uri = $_SERVER['REQUEST_URI'] ?? null;
 
         if ( $host && $request_uri ) {

--- a/src/Lolly/Listeners/LogOnHttpClientRequest.php
+++ b/src/Lolly/Listeners/LogOnHttpClientRequest.php
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-/*
+/**
  * @todo Investigate converting to use the Requests hooks.
  *   - fsockopen.after_send
  *   - requests.before_parse
@@ -58,7 +58,6 @@ class LogOnHttpClientRequest {
                 return;
             }
         }
-
 
         $log_context = [
             'wp_http_client' => new WpHttpClientContext(

--- a/tests/Support/WpunitTester.php
+++ b/tests/Support/WpunitTester.php
@@ -44,7 +44,7 @@ class WpunitTester extends \Codeception\Actor {
     /**
      * Create a test user with a specific role and log them in
      *
-     * @param string $role The user role
+     * @param string $role The user role.
      * @return \WP_User The created user
      */
     public function login_as_role( string $role = 'subscriber' ) {

--- a/tests/Wpunit/Rest/SettingsTest.php
+++ b/tests/Wpunit/Rest/SettingsTest.php
@@ -136,7 +136,7 @@ class SettingsTest extends WPRestApiTestCase {
 
         $this->assertEquals( 200, $get_response->get_status() );
 
-        $settings        = $get_response->get_data();
+        $settings       = $get_response->get_data();
         $lolly_settings = $settings['lolly_settings'];
 
         $this->assertTrue( $lolly_settings['enabled'] );
@@ -151,7 +151,7 @@ class SettingsTest extends WPRestApiTestCase {
 
     public function testSchemaIsProperlyDefined(): void {
         $registered_settings = get_registered_settings();
-        $lolly_setting      = $registered_settings['lolly_settings'];
+        $lolly_setting       = $registered_settings['lolly_settings'];
 
         $this->assertIsArray( $lolly_setting );
         $this->assertArrayHasKey( 'show_in_rest', $lolly_setting );

--- a/tests/Wpunit/_bootstrap.php
+++ b/tests/Wpunit/_bootstrap.php
@@ -1,5 +1,5 @@
 <?php
-/*
+/**
  * Wpunit suite bootstrap file.
  *
  * This file is loaded AFTER the suite modules are initialized, WordPress, plugins and themes are loaded.


### PR DESCRIPTION
Resolves linting errors so the new CI workflow passes. PHPCS now runs with
the -n flag to only fail on errors, not warnings. Added phpcs:ignore for
intentionally unsanitized $_SERVER values used in request URL logging, and
excluded the Codeception $I variable convention from snake_case rules.

Fixed PHP 8.4 implicit nullable deprecation in lolly() and added missing
return types to SettingsPage methods. Various auto-fixed formatting issues
from phpcbf and manual fixes for file comment styles.