### PR TITLE
chore: resolve remaining phpstan errors with type annotations

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -70,6 +70,8 @@
         <exclude name="WordPress.PHP.YodaConditions.NotYoda"/>
         <exclude name="WordPress.PHP.DevelopmentFunctions.error_log_error_log"/>
         <exclude name="WordPress.PHP.DevelopmentFunctions.error_log_print_r"/>
+        <!-- Deprecated in WPCS 3.3.0, will be removed in 4.0.0. -->
+        <exclude name="WordPress.PHP.POSIXFunctions"/>
     </rule>
 
     <rule ref="Generic.Commenting">

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,9 +10,11 @@ parameters:
     scanFiles:
         - vendor/php-stubs/wordpress-stubs/wordpress-stubs.php
 
+    # Treat PHPDoc types as uncertain to allow defensive runtime checks.
+    treatPhpDocTypesAsCertain: false
+
     ignoreErrors:
+        # LoggerInterface uses array, we use array<string, mixed> for clarity.
         -
-            messages:
-                - '#Method Lolly::[a-z]+\(\) has parameter \$context with no value type specified in iterable type array.#'
-                - '#Parameter \#[1-2] \$message \(string\) of method Lolly::[a-z]+\(\) should be contravariant with parameter#'
-            path: lolly.php
+            identifier: method.childParameterType
+            path: src/Lolly/Lolly.php

--- a/src/Lolly/Config/Config.php
+++ b/src/Lolly/Config/Config.php
@@ -103,6 +103,7 @@ class Config implements RedactorConfig, WhitelistConfig {
      * Whether the logging feature is enabled.
      */
     public function is_logging_enabled(): bool {
+        // @phpstan-ignore-next-line
         if ( defined( 'LOLLY_LOG_DISABLED' ) && LOLLY_LOG_DISABLED === true ) {
             return false;
         }
@@ -291,7 +292,9 @@ class Config implements RedactorConfig, WhitelistConfig {
      * @return HttpLoggingConfig|WP_Error
      */
     public function load_config_schema(): array|WP_Error {
-        $schema_path = trailingslashit( LOLLY_PLUGIN_DIR ) . 'resources/schemas/http-logging-config.json';
+        /** @var string $plugin_dir */
+        $plugin_dir  = LOLLY_PLUGIN_DIR;
+        $schema_path = trailingslashit( $plugin_dir ) . 'resources/schemas/http-logging-config.json';
         $schema      = \Lolly\Lib::load_json_file( $schema_path );
 
         if ( is_wp_error( $schema ) ) {
@@ -301,19 +304,6 @@ class Config implements RedactorConfig, WhitelistConfig {
         }
 
         return $schema;
-    }
-
-    /**
-     * Get the initialized Http logging config.
-     *
-     * @return HttpLoggingConfig|WP_Error
-     */
-    private function get_config(): array|WP_Error {
-        if ( $this->http_logging_config === null ) {
-            return new WP_Error( 'lolly.config.not_initialized', __( 'Lolly Log failed to load the configuration.', 'lolly' ) );
-        }
-
-        return $this->http_logging_config;
     }
 
     public function register_settings(): void {
@@ -375,8 +365,10 @@ class Config implements RedactorConfig, WhitelistConfig {
      * @return HttpLoggingConfig|WP_Error
      */
     private function load_default_config(): array|WP_Error {
-        $path   = trailingslashit( LOLLY_PLUGIN_DIR ) . 'config/default-logging-config.json';
-        $config = \Lolly\Lib::load_json_file( $path );
+        /** @var string $plugin_dir */
+        $plugin_dir = LOLLY_PLUGIN_DIR;
+        $path       = trailingslashit( $plugin_dir ) . 'config/default-logging-config.json';
+        $config     = \Lolly\Lib::load_json_file( $path );
 
         if ( $config instanceof WP_Error ) {
             $config->add( 'lolly.config', __( 'Lolly Log failed to load the default configuration.', 'lolly' ) );

--- a/src/Lolly/Lib.php
+++ b/src/Lolly/Lib.php
@@ -20,9 +20,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Lib {
     public static function get_full_request_url(): string {
         global $wp;
-        $protocol    = isset( $_SERVER['HTTPS'] ) && $_SERVER['HTTPS'] === 'on' ? 'https' : 'http';
+        $protocol = isset( $_SERVER['HTTPS'] ) && $_SERVER['HTTPS'] === 'on' ? 'https' : 'http';
         // phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- Intentionally unsanitized for logging.
-        $host        = $_SERVER['HTTP_HOST'] ?? null;
+        $host = $_SERVER['HTTP_HOST'] ?? null;
         // phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- Intentionally unsanitized for logging.
         $request_uri = $_SERVER['REQUEST_URI'] ?? null;
 
@@ -34,13 +34,13 @@ class Lib {
     }
 
     /**
-     * Load and decoce a JSON file.
+     * Load and decode a JSON file.
      *
      * @param string $path
      *
-     * @return array|WP_Error
+     * @return array<string, mixed>|WP_Error
      */
-    public static function load_json_file( string $path ) {
+    public static function load_json_file( string $path ): array|WP_Error {
         if ( file_exists( $path ) ) {
             $raw = file_get_contents( $path );
 

--- a/src/Lolly/Lib/Formatters/EcsLogStashFormatter.php
+++ b/src/Lolly/Lib/Formatters/EcsLogStashFormatter.php
@@ -159,11 +159,11 @@ class EcsLogStashFormatter extends NormalizerFormatter {
     /**
      * Checks if the context should be removed from the LogStash message.
      *
-     * @param array  $record
-     * @param string $key
-     * @param mixed  $value
-     *
      * A context is removed if it is duplicated by an extra field.
+     *
+     * @param array<string, mixed> $record
+     * @param string               $key
+     * @param mixed                $value
      */
     protected function should_remove_context( array $record, string $key, mixed $value ): bool {
         if (

--- a/src/Lolly/Lib/Processors/EcsHttpMessageProcessor.php
+++ b/src/Lolly/Lib/Processors/EcsHttpMessageProcessor.php
@@ -69,6 +69,9 @@ class EcsHttpMessageProcessor implements ProcessorInterface {
         return $record->with( context: $context, extra: $extra );
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     private function format_request( RequestInterface $request ): array {
         $result = [
             'method'  => strtolower( $request->getMethod() ),
@@ -93,6 +96,9 @@ class EcsHttpMessageProcessor implements ProcessorInterface {
         return $result;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     private function format_response( ResponseInterface $response ): array {
         $result = [
             'status_code' => $response->getStatusCode(),

--- a/src/Lolly/Lib/Processors/EcsTracingProcessor.php
+++ b/src/Lolly/Lib/Processors/EcsTracingProcessor.php
@@ -49,7 +49,7 @@ class EcsTracingProcessor implements ProcessorInterface, ResettableInterface {
         $this->uid = $this->generate_uid( strlen( $this->uid ) );
     }
 
-    private function generate_uid( $length ): string {
+    private function generate_uid( int $length ): string {
         return substr( hash( 'md5', uniqid( '', true ) ), 0, $length );
     }
 }

--- a/src/Lolly/Lib/Processors/EcsUrlProcessor.php
+++ b/src/Lolly/Lib/Processors/EcsUrlProcessor.php
@@ -54,6 +54,9 @@ class EcsUrlProcessor implements ProcessorInterface {
         return $record->with( context: $context, extra: $extra );
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     private function format_url( UriInterface $uri ): array {
         $result = [
             'original' => (string) $uri,

--- a/src/Lolly/Lib/Processors/PsrLogMessageProcessor.php
+++ b/src/Lolly/Lib/Processors/PsrLogMessageProcessor.php
@@ -81,7 +81,8 @@ class PsrLogMessageProcessor implements ProcessorInterface {
 
         if ( is_object( $context ) ) {
             if ( property_exists( $context, $key ) ) {
-                $value = $context->{$key};
+                /** @var mixed $value */
+                $value = $context->{$key}; // @phpstan-ignore-line Variable property access.
 
                 if ( $next === null ) {
                     return $this->interpolate( $value );
@@ -108,7 +109,7 @@ class PsrLogMessageProcessor implements ProcessorInterface {
         return '[undefined]';
     }
 
-    private function interpolate( $value ): string {
+    private function interpolate( mixed $value ): string {
         if ( is_object( $value ) ) {
             if ( $value instanceof Throwable ) {
                 return $value->getMessage();

--- a/src/Lolly/Lib/Services/Redactors/HttpMessage/DefaultRedactor.php
+++ b/src/Lolly/Lib/Services/Redactors/HttpMessage/DefaultRedactor.php
@@ -293,11 +293,11 @@ final class DefaultRedactor implements Redactors\HttpMessage {
     /**
      * Recursively redact keys from an associative array.
      *
-     * @param array               $data
-     * @param list<RedactionItem> $redactions
-     * @param bool                $is_query
+     * @param array<string, mixed> $data
+     * @param list<RedactionItem>  $redactions
+     * @param bool                 $is_query
      *
-     * @return array|string The redacted data.
+     * @return array<string, mixed> The redacted data.
      */
     private function redact_keys(
         array $data,

--- a/src/Lolly/Lib/Support/Arr.php
+++ b/src/Lolly/Lib/Support/Arr.php
@@ -60,16 +60,16 @@ class Arr {
     /**
      * Flatten a multi-dimensional associative array with dots.
      *
-     * @param iterable $array
-     * @param string   $prepend
+     * @param iterable<mixed> $array
+     * @param string          $prepend
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public static function dot( iterable $array, string $prepend = '' ): array {
         $results = [];
 
         foreach ( $array as $key => $value ) {
-            if ( is_array( $value ) && ! empty( $value ) ) {
+            if ( is_array( $value ) && count( $value ) > 0 ) {
                 $results = array_merge( $results, static::dot( $value, $prepend . $key . '.' ) );
             } else {
                 $results[ $prepend . $key ] = $value;
@@ -82,8 +82,8 @@ class Arr {
     /**
      * Determine if the given key exists in the provided array.
      *
-     * @param ArrayAccess|array $array
-     * @param string|int|float  $key
+     * @param ArrayAccess<array-key, mixed>|array<array-key, mixed> $array
+     * @param string|int|float                                      $key
      *
      * @return bool
      */
@@ -124,9 +124,9 @@ class Arr {
     /**
      * Get an item from an array using "dot" notation.
      *
-     * @param ArrayAccess|array $array
-     * @param string|int|null   $key
-     * @param mixed             $default
+     * @param ArrayAccess<array-key, mixed>|array<array-key, mixed> $array
+     * @param string|int|null                                       $key
+     * @param mixed                                                 $default
      *
      * @return mixed
      */
@@ -165,8 +165,8 @@ class Arr {
     /**
      * Whether a list contains a match to a predicate function.
      *
-     * @param array    $array
-     * @param callable $predicate
+     * @param array<mixed> $array
+     * @param callable     $predicate
      *
      * @return bool
      */
@@ -175,15 +175,15 @@ class Arr {
     }
 
     /**
-     * Whether a list contains a match to a predicate function.
+     * Whether a list does not contain a match to a predicate function.
      *
-     * @param array    $array
-     * @param callable $predicate
+     * @param array<mixed> $array
+     * @param callable     $predicate
      *
      * @return bool
      */
     public static function doesnt_contain( array $array, callable $predicate ): bool {
-        return ! static::find( $array, $predicate );
+        return static::find( $array, $predicate ) === null;
     }
 
     /**

--- a/src/Lolly/Lib/ValueObjects/LogContext/HttpMessageContext.php
+++ b/src/Lolly/Lib/ValueObjects/LogContext/HttpMessageContext.php
@@ -30,11 +30,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 class HttpMessageContext {
 
     /**
-     * @param Uri           $url
-     * @param Request       $request
-     * @param Response|null $response
-     * @param array|null    $request_body The parsed request body.
-     * @param array|null    $response_body The parsed response body.
+     * @param Uri                       $url
+     * @param Request                   $request
+     * @param Response|null             $response
+     * @param array<string, mixed>|null $request_body The parsed request body.
+     * @param array<string, mixed>|null $response_body The parsed response body.
      */
     public function __construct(
         readonly public Uri $url,

--- a/src/Lolly/Listeners/LogOnRestApiRequest.php
+++ b/src/Lolly/Listeners/LogOnRestApiRequest.php
@@ -35,7 +35,7 @@ class LogOnRestApiRequest {
      *
      * @param WP_REST_Response|WP_Error|mixed $result  Result to send to the client. Usually a `WP_REST_Response`.
      * @param WP_REST_Server                  $server  Server instance.
-     * @param WP_REST_Request                 $request Request used to generate the response.
+     * @param WP_REST_Request<array<mixed>>   $request Request used to generate the response.
      *
      * @return WP_REST_Response|WP_Error|mixed
      */

--- a/src/Lolly/Lolly.php
+++ b/src/Lolly/Lolly.php
@@ -212,8 +212,8 @@ final class Lolly implements LoggerInterface {
     /**
      * System is unusable.
      *
-     * @param string|Stringable $message
-     * @param array             $context
+     * @param string|Stringable    $message
+     * @param array<string, mixed> $context
      *
      * @return void
      *
@@ -229,8 +229,8 @@ final class Lolly implements LoggerInterface {
      * Example: Entire website down, database unavailable, etc. This should
      * trigger the SMS alerts and wake you up.
      *
-     * @param string|Stringable $message
-     * @param array             $context
+     * @param string|Stringable    $message
+     * @param array<string, mixed> $context
      *
      * @return void
      *
@@ -245,8 +245,8 @@ final class Lolly implements LoggerInterface {
      *
      * Example: Application component unavailable, unexpected exception.
      *
-     * @param string|Stringable $message
-     * @param array             $context
+     * @param string|Stringable    $message
+     * @param array<string, mixed> $context
      *
      * @return void
      *
@@ -260,8 +260,8 @@ final class Lolly implements LoggerInterface {
      * Runtime errors that do not require immediate action but should typically
      * be logged and monitored.
      *
-     * @param string|Stringable $message
-     * @param array             $context
+     * @param string|Stringable    $message
+     * @param array<string, mixed> $context
      *
      * @return void
      *
@@ -277,8 +277,8 @@ final class Lolly implements LoggerInterface {
      * Example: Use of deprecated APIs, poor use of an API, undesirable things
      * that are not necessarily wrong.
      *
-     * @param string|Stringable $message
-     * @param array             $context
+     * @param string|Stringable    $message
+     * @param array<string, mixed> $context
      *
      * @return void
      *
@@ -291,14 +291,14 @@ final class Lolly implements LoggerInterface {
     /**
      * Normal but significant events.
      *
-     * @param string $message
-     * @param array  $context
+     * @param string|Stringable    $message
+     * @param array<string, mixed> $context
      *
      * @return void
      *
      * @since 0.1.0
      */
-    public function notice( $message, array $context = [] ): void {
+    public function notice( string|Stringable $message, array $context = [] ): void {
         $this->log( LogLevel::NOTICE, $message, $context );
     }
 
@@ -307,8 +307,8 @@ final class Lolly implements LoggerInterface {
      *
      * Example: User logs in, SQL logs.
      *
-     * @param string|Stringable $message
-     * @param array             $context
+     * @param string|Stringable    $message
+     * @param array<string, mixed> $context
      *
      * @return void
      *
@@ -321,8 +321,8 @@ final class Lolly implements LoggerInterface {
     /**
      * Detailed debug information.
      *
-     * @param string|Stringable $message
-     * @param array             $context
+     * @param string|Stringable    $message
+     * @param array<string, mixed> $context
      *
      * @return void
      *
@@ -335,9 +335,9 @@ final class Lolly implements LoggerInterface {
     /**
      * Logs with an arbitrary level.
      *
-     * @param mixed             $level
-     * @param string|Stringable $message
-     * @param array             $context
+     * @param mixed                $level
+     * @param string|Stringable    $message
+     * @param array<string, mixed> $context
      *
      * @return void
      *

--- a/src/Lolly/Plugin/Uninstaller.php
+++ b/src/Lolly/Plugin/Uninstaller.php
@@ -10,7 +10,6 @@ declare( strict_types=1 );
 namespace Lolly\Plugin;
 
 use Lolly\Config\Config;
-use Lolly\lucatume\DI52\Container;
 
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
@@ -33,19 +32,14 @@ final class Uninstaller {
      */
     private static ?self $instance = null;
 
-    /**
-     * @param  Container $container The container.
-     */
-    private function __construct(
-        private readonly Container $container
-    ) {}
+    private function __construct() {}
 
     /**
      * Get the singleton instance.
      */
     public static function instance(): self {
         if ( self::$instance === null ) {
-            self::$instance = new self( lolly()->get_container() );
+            self::$instance = new self();
         }
 
         return self::$instance;

--- a/src/Lolly/ValueObjects/WpRestApiContext.php
+++ b/src/Lolly/ValueObjects/WpRestApiContext.php
@@ -26,7 +26,7 @@ class WpRestApiContext implements JsonSerializable {
     /**
      * @param WP_REST_Response|WP_Error|mixed $result  Result to send to the client. Usually a `WP_REST_Response|WP_Error`.
      * @param WP_REST_Server                  $server  Server instance.
-     * @param WP_REST_Request                 $request Request used to generate the response.
+     * @param WP_REST_Request<array<mixed>>   $request Request used to generate the response.
      * @param string                          $url The request URL.
      */
     public function __construct(


### PR DESCRIPTION
Adds missing array value type annotations throughout the codebase to satisfy
PHPStan level 6 requirements. Updates phpstan.neon.dist to allow defensive
runtime checks and ignore LoggerInterface contravariance warnings where we
use more specific types than the interface requires.

Removes unused get_config() method from Config and unused $container
property from Uninstaller. Excludes the deprecated WordPress.PHP.POSIXFunctions
sniff which will be removed in WPCS 4.0.