### PR TITLE
chore: add lando config for local development

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,11 +1,12 @@
+.cache/
+.claude/
 .git/
 .github/
 bin/
 docs/
 node_modules/
 tests/
-.cache
-.claude
+tmp/
 .distignore
 .editorconfig
 .gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ build
 
 **/.claude/settings.local.json
 **/.wip/
+
+# Lando
+/tmp/

--- a/.lando.yml
+++ b/.lando.yml
@@ -1,0 +1,71 @@
+name: lolly
+recipe: wordpress
+config:
+  php: "8.1"
+  via: nginx
+  database: mariadb:10.6
+  webroot: .
+  xdebug: true
+
+proxy:
+  appserver_nginx:
+    - lolly.lndo.site
+
+services:
+  appserver:
+    build_as_root:
+      - rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && pkill -o -USR2 php-fpm || true
+    overrides:
+      volumes:
+        - "./tmp/wordpress:/app"
+        - "./:/app/wp-content/plugins/lolly"
+        - "./tmp/logs:/var/log/lolly"
+      environment:
+        PHP_IDE_CONFIG: serverName=lolly
+        XDEBUG_SESSION_START: lando
+
+  database:
+    portforward: 4501
+
+  mailhog:
+    type: mailhog
+    hogfrom:
+      - appserver
+
+tooling:
+  xdebug-on:
+    service: appserver
+    description: Enable XDebug
+    cmd: docker-php-ext-enable xdebug && pkill -o -USR2 php-fpm && echo "XDebug enabled"
+    user: root
+
+  xdebug-off:
+    service: appserver
+    description: Disable XDebug
+    cmd: rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && pkill -o -USR2 php-fpm && echo "XDebug disabled"
+    user: root
+
+  install-wp:
+    service: appserver
+    description: Download and install WordPress with admin/password
+    cmd: /app/wp-content/plugins/lolly/bin/install-wp.sh
+
+  composer:
+    service: appserver
+    dir: /app/wp-content/plugins/lolly
+    cmd: /usr/local/bin/composer
+
+  phpcs:
+    service: appserver
+    dir: /app/wp-content/plugins/lolly
+    cmd: vendor/bin/phpcs
+
+  phpstan:
+    service: appserver
+    dir: /app/wp-content/plugins/lolly
+    cmd: vendor/bin/phpstan
+
+events:
+  post-start:
+    - appserver: /app/wp-content/plugins/lolly/bin/install-wp.sh
+

--- a/bin/install-wp.sh
+++ b/bin/install-wp.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+##################################################
+# Downloads and installs WordPress for local dev
+##################################################
+
+set -euo pipefail
+
+WP_PATH="/app"
+WP_URL="https://lolly.lndo.site"
+WP_TITLE="Lolly Dev"
+PLUGIN_PATH="${WP_PATH}/wp-content/plugins/lolly"
+LOG_DIR="/var/log/lolly"
+
+# Check if WordPress is already installed
+if wp --path="${WP_PATH}" core is-installed 2>/dev/null; then
+    echo "* WordPress already installed. Skipping..."
+    exit 0
+fi
+
+# Wait for database to be ready
+echo "* Waiting for database..."
+while ! mysqladmin ping -h"${DB_HOST:-database}" --silent; do
+    sleep 1
+done
+
+# Download WordPress if not present
+if [ ! -f "${WP_PATH}/wp-includes/version.php" ]; then
+    echo "* Downloading WordPress..."
+    wp core download --path="${WP_PATH}" --version=latest --force
+fi
+
+# Create wp-config.php if missing
+if [ ! -f "${WP_PATH}/wp-config.php" ]; then
+    echo "* Creating wp-config.php..."
+    wp config create \
+        --path="${WP_PATH}" \
+        --dbname="${DB_NAME:-wordpress}" \
+        --dbuser="${DB_USER:-wordpress}" \
+        --dbpass="${DB_PASSWORD:-wordpress}" \
+        --dbhost="${DB_HOST:-database}"
+
+    # Configure log directory (mounted to host for IDE access)
+    wp config set LOLLY_LOG_DIR "${LOG_DIR}" --path="${WP_PATH}" --type=constant
+
+    # Enable debug logging to file, not screen
+    wp config set WP_DEBUG true --path="${WP_PATH}" --type=constant --raw
+    wp config set WP_DEBUG_DISPLAY false --path="${WP_PATH}" --type=constant --raw
+    wp config set WP_DEBUG_LOG "${LOG_DIR}/debug.log" --path="${WP_PATH}" --type=constant
+fi
+
+# Ensure log directory exists
+mkdir -p "${LOG_DIR}"
+
+# Install WordPress
+echo "* Installing WordPress..."
+wp core install \
+    --path="${WP_PATH}" \
+    --url="${WP_URL}" \
+    --title="${WP_TITLE}" \
+    --admin_user=admin \
+    --admin_password=password \
+    --admin_email=admin@lndo.site \
+    --skip-email
+
+# Install plugin composer dependencies (strauss runs via post-install-cmd)
+if [ -f "${PLUGIN_PATH}/composer.json" ]; then
+    echo "* Installing plugin dependencies..."
+    cd "${PLUGIN_PATH}" && /usr/local/bin/composer install --no-interaction
+fi
+
+# Activate the plugin
+echo "* Activating lolly plugin..."
+wp --path="${WP_PATH}" plugin activate lolly
+
+echo "* Done! Visit ${WP_URL}/wp-admin (admin/password)"

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "lucatume/wp-browser": "^4.5"
     },
     "config": {
+        "autoloader-suffix": "Lolly",
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "phpstan/extension-installer": true
@@ -51,6 +52,12 @@
         }
     },
     "scripts": {
+        "post-install-cmd": [
+            "@strauss"
+        ],
+        "post-update-cmd": [
+            "@strauss"
+        ],
         "analyse": [
             "@php vendor/bin/phpstan analyse --memory-limit=4G --no-progress --no-interaction --ansi"
         ],


### PR DESCRIPTION
Adds Lando-based WordPress environment with auto-install on start, XDebug
toggle, and debug logging to tmp/logs for IDE access. Credentials are
admin/password.

Fixes WP-CLI autoloader conflict with composer suffix and runs strauss
automatically via post-install-cmd.