### PR TITLE
test: add http listener integration tests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,32 +1,32 @@
 name: Lint
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
+    push:
+        branches:
+            - main
+    pull_request:
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
+    lint:
+        runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 8.1
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: 8.1
 
-      - name: Install Dependencies
-        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+            - name: Install Dependencies
+              run: composer install --no-interaction --prefer-dist --optimize-autoloader
 
-      - name: Build Prefixed Dependencies
-        run: composer strauss
+            - name: Build Prefixed Dependencies
+              run: composer strauss
 
-      - name: Run PHPCS
-        run: composer lint
+            - name: Run PHPCS
+              run: composer lint -- -n
 
-      - name: Run PHPStan
-        run: composer analyse
+            - name: Run PHPStan
+              run: composer analyse

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
             "@php vendor/bin/phpstan analyse --memory-limit=4G --no-progress --no-interaction --ansi"
         ],
         "lint": [
-            "@php vendor/bin/phpcs -d memory_limit=2G -s -n"
+            "@php vendor/bin/phpcs -d memory_limit=2G -s"
         ],
         "lint:fix": [
             "@php vendor/bin/phpcbf -d memory_limit=2G"

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -3,8 +3,8 @@ module.exports = {
 		const files = filenames.join(' ');
 		return [
 			`php -d display_errors=1 -l ${files}`,
-			`vendor/bin/phpcs --standard=phpcs.xml.dist ${files}`,
-			`vendor/bin/phpstan analyse --memory-limit=4G ${files}`,
+			`vendor/bin/phpcs --standard=phpcs.xml.dist -n ${files}`,
+			`vendor/bin/phpstan analyse --memory-limit=4G --no-progress`,
 		];
 	},
 	'**/*.{js,jsx,ts,tsx}': (filenames) => {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -113,8 +113,19 @@
         <exclude-pattern>*/tests/*</exclude-pattern>
     </rule>
 
-    <!-- Allow $I variable in Codeception tests (convention). -->
+    <!-- Allow camelCase in Codeception tests (convention). -->
     <rule ref="WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase">
+        <exclude-pattern>*/tests/*</exclude-pattern>
+    </rule>
+    <rule ref="WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase">
+        <exclude-pattern>*/tests/*</exclude-pattern>
+    </rule>
+    <rule ref="WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase">
+        <exclude-pattern>*/tests/*</exclude-pattern>
+    </rule>
+
+    <!-- Allow Codeception lifecycle methods (_before, _after). -->
+    <rule ref="PSR2.Methods.MethodDeclaration.Underscore">
         <exclude-pattern>*/tests/*</exclude-pattern>
     </rule>
 

--- a/src/Lolly/Config/Config.php
+++ b/src/Lolly/Config/Config.php
@@ -95,6 +95,15 @@ class Config implements RedactorConfig, WhitelistConfig {
         }
     }
 
+    /**
+     * Reload the configuration from the database.
+     *
+     * Useful when settings have been updated and the cached config needs to be refreshed.
+     */
+    public function reload(): void {
+        $this->http_logging_config = $this->load();
+    }
+
     public function get_log_dir_path(): string {
         return $this->log_dir_path;
     }

--- a/src/Lolly/Processors/WpRestApiProcessor.php
+++ b/src/Lolly/Processors/WpRestApiProcessor.php
@@ -79,7 +79,7 @@ class WpRestApiProcessor implements ProcessorInterface {
                 );
 
                 if ( $value->result->is_error() ) {
-                    if ( ! $context['wp_error'] ) {
+                    if ( ! isset( $context['wp_error'] ) ) {
                         $context['wp_error'] = $value->result->as_error();
                     }
                 }

--- a/tests/Support/Helper/Lolly.php
+++ b/tests/Support/Helper/Lolly.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support\Helper;
+
+use Codeception\Module;
+use Codeception\TestInterface;
+use Lolly\Config\Config;
+use Lolly\Log\LoggerFactory;
+use Lolly\Monolog\Handler\TestHandler;
+use Lolly\Monolog\LogRecord;
+use Lolly\Psr\Log\LoggerInterface;
+
+/**
+ * Lolly-specific test helper.
+ *
+ * Provides methods for configuring plugin settings and capturing logs.
+ */
+class Lolly extends Module {
+    private ?TestHandler $testHandler = null;
+    private bool $loggerFaked         = false;
+
+    public function _after( TestInterface $test ): void {
+        delete_option( Config::OPTION_SLUG );
+
+        remove_all_actions( 'http_api_debug' );
+        remove_all_filters( 'rest_post_dispatch' );
+
+        if ( $this->loggerFaked ) {
+            $this->restoreLogger();
+        }
+
+        $this->testHandler = null;
+    }
+
+    /**
+     * Replace the logger with a fake that captures log records.
+     *
+     * The fake logger uses the same processors as the real logger,
+     * but writes to a TestHandler instead of a file.
+     */
+    public function fakeLogger(): void {
+        $this->testHandler = new TestHandler();
+        $this->loggerFaked = true;
+
+        /** @var LoggerFactory $factory */
+        $factory = lolly( LoggerFactory::class );
+        $logger  = $factory->make();
+
+        // Replace the file handler with our test handler.
+        $logger->setHandlers( [ $this->testHandler ] );
+
+        // Rebind the singleton to use our fake logger.
+        lolly()->singleton( LoggerInterface::class, static fn() => $logger );
+    }
+
+    /**
+     * Restore the real logger singleton.
+     */
+    private function restoreLogger(): void {
+        lolly()->singleton(
+            LoggerInterface::class,
+            static fn() => lolly( LoggerFactory::class )->make()
+        );
+
+        $this->loggerFaked = false;
+    }
+
+    /**
+     * Update plugin settings and reload the config.
+     *
+     * @param array<string, mixed> $settings Settings to merge with defaults.
+     */
+    public function updateSettings( array $settings ): void {
+        $defaults = [
+            'version'                        => 1,
+            'enabled'                        => false,
+            'wp_http_client_logging_enabled' => false,
+            'wp_rest_logging_enabled'        => false,
+            'http_redactions_enabled'        => false,
+            'http_whitelist_enabled'         => false,
+            'http_redactions'                => [],
+            'http_whitelist'                 => [],
+        ];
+
+        update_option( Config::OPTION_SLUG, array_merge( $defaults, $settings ) );
+
+        // Reload the cached config.
+        lolly( Config::class )->reload();
+    }
+
+    /**
+     * Grab all captured log records.
+     *
+     * @return LogRecord[]
+     */
+    public function grabLogRecords(): array {
+        return $this->testHandler?->getRecords() ?? [];
+    }
+
+    /**
+     * Grab the number of captured log records.
+     */
+    public function grabLogCount(): int {
+        return count( $this->grabLogRecords() );
+    }
+
+    /**
+     * Clear all captured log records.
+     */
+    public function clearLogRecords(): void {
+        $this->testHandler?->clear();
+    }
+
+    /**
+     * Check if a message was logged (partial match).
+     *
+     * @param string $message Message to search for.
+     * @param string $level   Optional log level to filter by.
+     */
+    protected function hasLogMessage( string $message, string $level = '' ): bool {
+        foreach ( $this->grabLogRecords() as $record ) {
+            if ( $level !== '' && strtolower( $record->level->name ) !== strtolower( $level ) ) {
+                continue;
+            }
+
+            if ( str_contains( $record->message, $message ) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Grab records that match a message (partial match).
+     *
+     * @param string $message Message to search for.
+     *
+     * @return LogRecord[]
+     */
+    public function grabLogRecordsWithMessage( string $message ): array {
+        $matching = [];
+
+        foreach ( $this->grabLogRecords() as $record ) {
+            if ( str_contains( $record->message, $message ) ) {
+                $matching[] = $record;
+            }
+        }
+
+        return $matching;
+    }
+
+    /**
+     * Assert that a specific number of log records were captured.
+     *
+     * @param int $expected Expected count.
+     */
+    public function seeLogCount( int $expected ): void {
+        $actual = $this->grabLogCount();
+        $this->assertEquals(
+            $expected,
+            $actual,
+            "Expected {$expected} log records, but found {$actual}."
+        );
+    }
+
+    /**
+     * Assert that a log message was recorded.
+     *
+     * @param string $message Message to find.
+     * @param string $level   Optional log level.
+     */
+    public function seeLogMessage( string $message, string $level = '' ): void {
+        $this->assertTrue(
+            $this->hasLogMessage( $message, $level ),
+            "Expected to find log message containing '{$message}'" . ( $level ? " at level '{$level}'" : '' ) . '.'
+        );
+    }
+
+    /**
+     * Assert that no log message was recorded.
+     *
+     * @param string $message Message to check.
+     * @param string $level   Optional log level.
+     */
+    public function dontSeeLogMessage( string $message, string $level = '' ): void {
+        $this->assertFalse(
+            $this->hasLogMessage( $message, $level ),
+            "Did not expect to find log message containing '{$message}'" . ( $level ? " at level '{$level}'" : '' ) . '.'
+        );
+    }
+}

--- a/tests/Wpunit.suite.yml
+++ b/tests/Wpunit.suite.yml
@@ -8,6 +8,7 @@ modules:
     enabled:
         - Asserts
         - WPLoader
+        - \Tests\Support\Helper\Lolly
     config:
         WPLoader:
             wpRootFolder: "%WP_ROOT_FOLDER%"

--- a/tests/Wpunit/Listeners/LogOnHttpClientRequestTest.php
+++ b/tests/Wpunit/Listeners/LogOnHttpClientRequestTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wpunit\Listeners;
+
+use Lolly\Listeners\LogOnHttpClientRequest;
+use lucatume\WPBrowser\TestCase\WPTestCase;
+use Tests\Support\WpunitTester;
+use WP_Error;
+
+/**
+ * @property WpunitTester $tester
+ */
+class LogOnHttpClientRequestTest extends WPTestCase {
+    private const TEST_URL = 'https://api.example.com/test';
+
+    public function _before(): void {
+        parent::_before();
+
+        $this->tester->updateSettings(
+            [
+                'enabled'                        => true,
+                'wp_http_client_logging_enabled' => true,
+            ]
+        );
+
+        $this->tester->fakeLogger();
+
+        add_action(
+            'http_api_debug',
+            lolly()->callback( LogOnHttpClientRequest::class, 'handle' ),
+            999,
+            5
+        );
+    }
+
+    public function testLogsSuccessfulHttpRequest(): void {
+        $response = $this->buildResponse( 200, '{"success": true}' );
+
+        do_action( 'http_api_debug', $response, 'response', 'Requests', $this->buildRequestArgs(), self::TEST_URL );
+
+        $this->tester->seeLogMessage( 'HTTP client request.', 'info' );
+    }
+
+    public function testLogsHttpErrorResponseAtInfoLevel(): void {
+        $response = $this->buildResponse( 500, '{"error": "Server error"}' );
+
+        do_action( 'http_api_debug', $response, 'response', 'Requests', $this->buildRequestArgs(), self::TEST_URL );
+
+        // HTTP 500 is not a WP_Error, so it logs at info level.
+        // WP_Error (e.g., connection timeout) would log at error level.
+        $this->tester->seeLogMessage( 'HTTP client request.', 'info' );
+    }
+
+    public function testLogsWpErrorAtErrorLevel(): void {
+        $error = new WP_Error( 'http_request_failed', 'Connection timed out' );
+
+        do_action( 'http_api_debug', $error, 'response', 'Requests', $this->buildRequestArgs(), self::TEST_URL );
+
+        $this->tester->seeLogMessage( 'HTTP client request.', 'error' );
+    }
+
+    public function testIgnoresWpCronRequests(): void {
+        $cronUrl  = 'https://example.com/wp-cron.php?doing_wp_cron=123';
+        $response = $this->buildResponse( 200 );
+
+        do_action( 'http_api_debug', $response, 'response', 'Requests', $this->buildRequestArgs(), $cronUrl );
+
+        $this->tester->seeLogCount( 0 );
+    }
+
+    public function testIgnoresLoopbackRequests(): void {
+        $siteUrl  = trailingslashit( get_site_url() );
+        $response = $this->buildResponse( 200 );
+
+        do_action( 'http_api_debug', $response, 'response', 'Requests', $this->buildRequestArgs(), $siteUrl );
+
+        $this->tester->seeLogCount( 0 );
+    }
+
+    public function testRespectsWhitelistWhenEnabled(): void {
+        $this->tester->updateSettings(
+            [
+                'enabled'                        => true,
+                'wp_http_client_logging_enabled' => true,
+                'http_whitelist_enabled'         => true,
+                'http_whitelist'                 => [
+                    [
+                        'host'  => 'allowed.example.com',
+                        'paths' => [ [ 'path' => '*' ] ],
+                    ],
+                ],
+            ]
+        );
+
+        $response    = $this->buildResponse( 200, '{}' );
+        $requestArgs = $this->buildRequestArgs();
+
+        // Non-whitelisted host should not be logged.
+        do_action( 'http_api_debug', $response, 'response', 'Requests', $requestArgs, 'https://blocked.example.com/api' );
+        $this->tester->seeLogCount( 0 );
+
+        // Whitelisted host should be logged.
+        do_action( 'http_api_debug', $response, 'response', 'Requests', $requestArgs, 'https://allowed.example.com/api' );
+        $this->tester->seeLogCount( 1 );
+    }
+
+    public function testLogsAllHostsWhenWhitelistDisabled(): void {
+        $response = $this->buildResponse( 200, '{}' );
+
+        do_action( 'http_api_debug', $response, 'response', 'Requests', $this->buildRequestArgs(), 'https://any.example.com/api' );
+
+        $this->tester->seeLogCount( 1 );
+    }
+
+    public function testCapturesRequestContext(): void {
+        $response    = $this->buildResponse( 200, '{"data": "test"}', [ 'Content-Type' => 'application/json' ] );
+        $requestArgs = $this->buildRequestArgs( 'POST', [ 'body' => [ 'key' => 'value' ] ] );
+
+        do_action( 'http_api_debug', $response, 'response', 'Requests', $requestArgs, self::TEST_URL );
+
+        $records = $this->tester->grabLogRecords();
+        $this->assertCount( 1, $records );
+
+        $context = $records[0]->context;
+        $this->assertArrayHasKey( 'wp_http_client', $context );
+    }
+
+    /**
+     * Build a response array matching WordPress HTTP API format.
+     *
+     * @param int                   $status  HTTP status code.
+     * @param string                $body    Response body.
+     * @param array<string, string> $headers Response headers.
+     *
+     * @return array<string, mixed>
+     */
+    private function buildResponse( int $status = 200, string $body = '', array $headers = [] ): array {
+        return [
+            'response' => [
+                'code'    => $status,
+                'message' => get_status_header_desc( $status ),
+            ],
+            'body'     => $body,
+            'headers'  => $headers,
+            'cookies'  => [],
+        ];
+    }
+
+    /**
+     * Build request args matching WordPress HTTP API format.
+     *
+     * @param string               $method HTTP method.
+     * @param array<string, mixed> $args   Additional request args.
+     *
+     * @return array<string, mixed>
+     */
+    private function buildRequestArgs( string $method = 'GET', array $args = [] ): array {
+        return array_merge(
+            [
+                'method'  => $method,
+                'headers' => [],
+                'body'    => null,
+            ],
+            $args
+        );
+    }
+}

--- a/tests/Wpunit/Listeners/LogOnRestApiRequestTest.php
+++ b/tests/Wpunit/Listeners/LogOnRestApiRequestTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wpunit\Listeners;
+
+use Lolly\Listeners\LogOnRestApiRequest;
+use lucatume\WPBrowser\TestCase\WPTestCase;
+use Tests\Support\WpunitTester;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * @property WpunitTester $tester
+ */
+class LogOnRestApiRequestTest extends WPTestCase {
+    private const TEST_ROUTE = '/wp/v2/posts';
+
+    /**
+     * @var array<string, mixed> Original $_SERVER values to restore after tests.
+     */
+    private array $originalServer = [];
+
+    public function _before(): void {
+        parent::_before();
+
+        $this->originalServer = $_SERVER;
+        $this->setServerVars( 'example.com', '/wp-json' . self::TEST_ROUTE );
+
+        $this->tester->updateSettings(
+            [
+                'enabled'                 => true,
+                'wp_rest_logging_enabled' => true,
+            ]
+        );
+
+        $this->tester->fakeLogger();
+
+        add_filter(
+            'rest_post_dispatch',
+            lolly()->callback( LogOnRestApiRequest::class, 'handle' ),
+            999,
+            3
+        );
+    }
+
+    public function _after(): void {
+        $_SERVER = $this->originalServer;
+
+        parent::_after();
+    }
+
+    public function testLogsSuccessfulRestRequest(): void {
+        $request  = new WP_REST_Request( 'GET', self::TEST_ROUTE );
+        $response = new WP_REST_Response( [ 'data' => 'test' ], 200 );
+
+        apply_filters( 'rest_post_dispatch', $response, rest_get_server(), $request );
+
+        $this->tester->seeLogMessage( 'HTTP REST request.', 'info' );
+    }
+
+    public function testLogsErrorResponseAtErrorLevel(): void {
+        $request = new WP_REST_Request( 'GET', self::TEST_ROUTE );
+
+        // Create error response with the structure WP_REST_Response::as_error() expects.
+        $error    = new WP_Error( 'rest_not_found', 'Not found', [ 'status' => 404 ] );
+        $response = rest_convert_error_to_response( $error );
+
+        apply_filters( 'rest_post_dispatch', $response, rest_get_server(), $request );
+
+        $this->tester->seeLogMessage( 'HTTP REST request.', 'error' );
+    }
+
+    public function testLogsWpErrorAtErrorLevel(): void {
+        $request = new WP_REST_Request( 'GET', self::TEST_ROUTE );
+        $error   = new WP_Error( 'rest_error', 'Something went wrong' );
+
+        apply_filters( 'rest_post_dispatch', $error, rest_get_server(), $request );
+
+        $this->tester->seeLogMessage( 'HTTP REST request.', 'error' );
+    }
+
+    public function testRespectsWhitelistWhenEnabled(): void {
+        $this->tester->updateSettings(
+            [
+                'enabled'                 => true,
+                'wp_rest_logging_enabled' => true,
+                'http_whitelist_enabled'  => true,
+                'http_whitelist'          => [
+                    [
+                        'host'  => 'allowed.example.com',
+                        'paths' => [ [ 'path' => '*' ] ],
+                    ],
+                ],
+            ]
+        );
+
+        $request  = new WP_REST_Request( 'GET', self::TEST_ROUTE );
+        $response = new WP_REST_Response( [ 'data' => 'test' ], 200 );
+        $server   = rest_get_server();
+
+        // Non-whitelisted host should not be logged.
+        $this->setServerVars( 'blocked.example.com', '/wp-json' . self::TEST_ROUTE );
+        apply_filters( 'rest_post_dispatch', $response, $server, $request );
+        $this->tester->seeLogCount( 0 );
+
+        // Whitelisted host should be logged.
+        $this->setServerVars( 'allowed.example.com', '/wp-json' . self::TEST_ROUTE );
+        apply_filters( 'rest_post_dispatch', $response, $server, $request );
+        $this->tester->seeLogCount( 1 );
+    }
+
+    public function testLogsAllHostsWhenWhitelistDisabled(): void {
+        $request  = new WP_REST_Request( 'GET', self::TEST_ROUTE );
+        $response = new WP_REST_Response( [ 'data' => 'test' ], 200 );
+
+        apply_filters( 'rest_post_dispatch', $response, rest_get_server(), $request );
+
+        $this->tester->seeLogCount( 1 );
+    }
+
+    public function testCapturesRequestContext(): void {
+        $request = new WP_REST_Request( 'POST', self::TEST_ROUTE );
+        $request->set_body_params( [ 'title' => 'Test Post' ] );
+        $response = new WP_REST_Response( [ 'id' => 1 ], 201 );
+
+        apply_filters( 'rest_post_dispatch', $response, rest_get_server(), $request );
+
+        $this->tester->seeLogMessage( 'HTTP REST request.', 'info' );
+        $this->tester->seeLogCount( 1 );
+    }
+
+    /**
+     * Set $_SERVER variables for the request URL.
+     *
+     * @param string $host       The host name.
+     * @param string $requestUri The request URI.
+     */
+    private function setServerVars( string $host, string $requestUri ): void {
+        $_SERVER['HTTP_HOST']   = $host;
+        $_SERVER['REQUEST_URI'] = $requestUri;
+        $_SERVER['HTTPS']       = 'on';
+    }
+}


### PR DESCRIPTION
Tests for LogOnHttpClientRequest and LogOnRestApiRequest listeners verify
logging behavior for successful requests, errors, whitelist filtering, and
cron/loopback exclusions. The tests call WordPress hooks directly rather than
mocking HTTP to exercise the actual listener code paths.

Adds a Lolly test helper with fakeLogger() to swap the logger singleton with
a TestHandler for capturing log records. Also fixes an undefined array key
error in WpRestApiProcessor discovered during testing.