### PR TITLE
feat: add user event logging

### DIFF
--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -1,0 +1,65 @@
+# Running Tests
+
+This project uses Codeception with slic (Docker-based WordPress testing environment).
+
+## Running Tests
+
+Tests must be run from the parent directory (`~/Projects`) using slic:
+
+```bash
+# Point slic at the plugins directory (if not already done)
+slic here
+
+# Select this plugin
+slic use lolly
+
+# Run all tests
+slic run Wpunit
+
+# Run tests in a directory
+slic run Wpunit "Listeners/"
+
+# Run a specific test file
+slic run Wpunit "Listeners/LogOnUserCreatedTest.php"
+
+# Run a specific test method
+slic run Wpunit "Listeners/LogOnUserCreatedTest.php:testLogsUserCreation"
+```
+
+## Debugging Tests
+
+To debug tests, use `codecept_debug()` in your test code and run with the `--debug` flag:
+
+```php
+// In your test file
+codecept_debug($variable);
+codecept_debug($records[0]->context);
+```
+
+```bash
+# Run with debug output
+slic run Wpunit:TestName -- --debug
+```
+
+## Interactive Debugging
+
+For more complex debugging, drop into the slic shell:
+
+```bash
+slic shell
+cd /var/www/html/wp-content/plugins/lolly
+vendor/bin/codecept run Wpunit --debug
+```
+
+## Test Helpers
+
+The `WpunitTester` provides helper methods:
+
+- `$this->tester->loginAsAdmin()` - Log in as administrator
+- `$this->tester->loginAsRole('editor')` - Log in as specific role
+- `$this->tester->logout()` - Log out current user
+- `$this->tester->fakeLogger()` - Capture log records
+- `$this->tester->updateSettings([...])` - Update plugin settings
+- `$this->tester->seeLogMessage('message', 'level')` - Assert log message exists
+- `$this->tester->seeLogCount(n)` - Assert number of log records
+- `$this->tester->grabLogRecords()` - Get all captured log records

--- a/config/default-logging-config.json
+++ b/config/default-logging-config.json
@@ -6,6 +6,7 @@
     "http_whitelist_enabled": false,
     "wp_rest_logging_enabled": true,
     "wp_http_client_logging_enabled": true,
+    "wp_user_event_logging_enabled": true,
     "http_redactions": [
         {
             "host": "*",
@@ -13,14 +14,18 @@
                 {
                     "path": "*",
                     "redactions": [
-                        {"type": "*", "value": "password"},
-                        {"type": "*", "value": "password_confirm"},
-                        {"type": "*", "value": "password_confirmation"},
-                        {"type": "*", "value": "api_key"},
-                        {"type": "*", "value": "apikey"},
-                        {"type": "*", "value": "hash"},
-                        {"type": "header", "value": "cookie", "remove": true},
-                        {"type": "header", "value": "authorization", "remove": true}
+                        { "type": "*", "value": "password" },
+                        { "type": "*", "value": "password_confirm" },
+                        { "type": "*", "value": "password_confirmation" },
+                        { "type": "*", "value": "api_key" },
+                        { "type": "*", "value": "apikey" },
+                        { "type": "*", "value": "hash" },
+                        { "type": "header", "value": "cookie", "remove": true },
+                        {
+                            "type": "header",
+                            "value": "authorization",
+                            "remove": true
+                        }
                     ]
                 }
             ]
@@ -31,7 +36,7 @@
                 {
                     "path": "/news/feed/",
                     "redactions": [
-                        {"type": "response", "value": "*", "remove": true}
+                        { "type": "response", "value": "*", "remove": true }
                     ]
                 }
             ]
@@ -42,50 +47,50 @@
                 {
                     "path": "/core/checksums/",
                     "redactions": [
-                        {"type": "response", "value": "*", "remove": true}
+                        { "type": "response", "value": "*", "remove": true }
                     ],
                     "glob": true
                 },
                 {
                     "path": "/core/version-check/",
                     "redactions": [
-                        {"type": "query", "value": "*", "remove": true},
-                        {"type": "response", "value": "*", "remove": true}
+                        { "type": "query", "value": "*", "remove": true },
+                        { "type": "response", "value": "*", "remove": true }
                     ],
                     "glob": true
                 },
                 {
                     "path": "/plugins/info/",
                     "redactions": [
-                        {"type": "response", "value": "*", "remove": true}
+                        { "type": "response", "value": "*", "remove": true }
                     ],
                     "glob": true
                 },
                 {
                     "path": "/plugins/update-check/",
                     "redactions": [
-                        {"type": "response", "value": "*", "remove": true}
+                        { "type": "response", "value": "*", "remove": true }
                     ],
                     "glob": true
                 },
                 {
                     "path": "/themes/info/",
                     "redactions": [
-                        {"type": "response", "value": "*", "remove": true}
+                        { "type": "response", "value": "*", "remove": true }
                     ],
                     "glob": true
                 },
                 {
                     "path": "/themes/update-check/",
                     "redactions": [
-                        {"type": "response", "value": "*", "remove": true}
+                        { "type": "response", "value": "*", "remove": true }
                     ],
                     "glob": true
                 },
                 {
                     "path": "/translations/core/",
                     "redactions": [
-                        {"type": "response", "value": "*", "remove": true}
+                        { "type": "response", "value": "*", "remove": true }
                     ],
                     "glob": true
                 }
@@ -97,7 +102,7 @@
                 {
                     "path": "/feed/",
                     "redactions": [
-                        {"type": "response", "value": "*", "remove": true}
+                        { "type": "response", "value": "*", "remove": true }
                     ]
                 }
             ]

--- a/docs/plans/multisite-user-event-logging.md
+++ b/docs/plans/multisite-user-event-logging.md
@@ -1,0 +1,67 @@
+# Plan: Multisite User Event Logging
+
+## Problem Statement
+
+In WordPress multisite installations, users can be added to or removed from individual sites without being created or deleted at the network level. The current user event logging only captures network-level user lifecycle events, missing site-level membership changes.
+
+## Why This Matters
+
+On a multisite network:
+
+- A user can exist on the network but not have access to a specific site
+- Administrators can grant or revoke site access without deleting the user
+- These membership changes are security-relevant events that should be auditable
+
+Without logging these events, administrators have no visibility into who was granted or revoked access to specific sites.
+
+## Proposed Events
+
+| Event | Hook | Description |
+|-------|------|-------------|
+| User added to site | `add_user_to_blog` | User granted access to a site |
+| User removed from site | `remove_user_from_blog` | User's access to a site revoked |
+
+### Hook Signatures
+
+```php
+do_action('add_user_to_blog', int $user_id, string $role, int $blog_id);
+do_action('remove_user_from_blog', int $user_id, int $blog_id, int $reassign);
+```
+
+## Logged Data
+
+**User added to site:**
+- Target user
+- Site ID / site name
+- Role assigned on that site
+- Actor (admin who granted access)
+
+**User removed from site:**
+- Target user
+- Site ID / site name
+- Reassignment user (if content was reassigned)
+- Actor (admin who revoked access)
+
+## Configuration
+
+These listeners should only be active when:
+1. WordPress is running in multisite mode (`is_multisite()`)
+2. User event logging is enabled
+
+No additional configuration setting needed - multisite events are a natural extension of user event logging.
+
+## Testing
+
+**Research needed:** Determine how to test multisite functionality with our current setup.
+
+Options to investigate:
+- WpBrowser's `multisite: true` configuration in WPLoader
+- Separate test suite for multisite (e.g., `WpunitMultisite.suite.yml`)
+- Whether slic supports multisite WordPress instances
+- Codeception environments for toggling single site vs multisite
+
+## Open Questions
+
+1. Should we log the site URL/name in addition to the blog ID for readability?
+2. Should `switch_blog` events be logged, or is that too noisy?
+3. How do super admin role changes interact with site-level access?

--- a/docs/user-event-logging.md
+++ b/docs/user-event-logging.md
@@ -1,0 +1,85 @@
+# User Event Logging
+
+Lolly can log WordPress user lifecycle events for auditing purposes. This feature is controlled by the **User Event Logging** toggle in the settings page.
+
+## Events Captured
+
+### User Created
+
+Logged when a new user account is created via `wp_insert_user()` or the admin dashboard.
+
+**Hook:** `user_register`
+
+**Logged data:**
+- Target user (the new account)
+- Assigned roles
+- Actor (admin who created the account, if applicable)
+
+### User Deleted
+
+Logged when a user account is deleted via `wp_delete_user()` or the admin dashboard.
+
+**Hook:** `delete_user`
+
+**Logged data:**
+- Target user (the deleted account)
+- User's roles at time of deletion
+- Reassignment user (if content was reassigned to another user)
+- Actor (admin who deleted the account)
+
+### User Role Changed
+
+Logged when a user's role is replaced via `WP_User::set_role()` or the admin dashboard.
+
+**Hook:** `set_user_role`
+
+**Logged data:**
+- Target user (whose role changed)
+- New role
+- Previous roles
+- Actor (admin who made the change, if different from target)
+
+### User Role Added
+
+Logged when an additional role is added to a user via `WP_User::add_role()`.
+
+**Hook:** `add_user_role`
+
+**Logged data:**
+- Target user
+- Added role
+- Actor (admin who made the change, if different from target)
+
+### User Role Removed
+
+Logged when a role is removed from a user via `WP_User::remove_role()`.
+
+**Hook:** `remove_user_role`
+
+**Logged data:**
+- Target user
+- Removed role
+- Actor (admin who made the change, if different from target)
+
+## Log Format
+
+Events are logged at `info` level with ECS-compatible formatting:
+
+```json
+{
+  "@timestamp": "2026-01-23T10:00:00.000Z",
+  "message": "User created.",
+  "log.level": "info",
+  "user": { "id": 1 },
+  "ctxt_target_user": { "id": 5 },
+  "ctxt_roles": ["subscriber"]
+}
+```
+
+The `user` field contains the actor (who performed the action). The `target_user` field contains the affected user.
+
+## Configuration
+
+Enable or disable via **Settings > Lolly Log > User Event Logging**.
+
+When disabled, no user lifecycle events are logged. Other logging features (REST API, HTTP Client) are unaffected.

--- a/resources/js/components/settings-page.tsx
+++ b/resources/js/components/settings-page.tsx
@@ -88,6 +88,22 @@ export default function SettingsPage(): React.ReactNode {
                             __nextHasNoMarginBottom
                         />
                         <ToggleControl
+                            label={__('User Event Logging', 'lolly')}
+                            checked={settings.wp_user_event_logging_enabled}
+                            onChange={(value: boolean) =>
+                                editSetting(
+                                    'wp_user_event_logging_enabled',
+                                    value
+                                )
+                            }
+                            disabled={!settings.enabled}
+                            help={__(
+                                'Log user creation, deletion, and role changes.',
+                                'lolly'
+                            )}
+                            __nextHasNoMarginBottom
+                        />
+                        <ToggleControl
                             label={__('HTTP Redactions', 'lolly')}
                             checked={settings.http_redactions_enabled}
                             onChange={(value: boolean) =>

--- a/resources/schemas/http-logging-config.json
+++ b/resources/schemas/http-logging-config.json
@@ -21,6 +21,10 @@
             "description": "Whether the WordPress HTTP client logging feature is enabled.",
             "type": "boolean"
         },
+        "wp_user_event_logging_enabled": {
+            "description": "Whether user event logging is enabled (creation, deletion, role changes).",
+            "type": "boolean"
+        },
         "http_redactions_enabled": {
             "description": "Whether the HTTP logging redaction feature is enabled.",
             "type": "boolean"
@@ -62,7 +66,13 @@
                                             "type": {
                                                 "description": "The HTTP redaction type.",
                                                 "type": "string",
-                                                "enum": ["*", "query", "header", "request", "response"]
+                                                "enum": [
+                                                    "*",
+                                                    "query",
+                                                    "header",
+                                                    "request",
+                                                    "response"
+                                                ]
                                             },
                                             "value": {
                                                 "description": "The value to match a redaction target property.",
@@ -73,10 +83,7 @@
                                                 "type": "boolean"
                                             }
                                         },
-                                        "required": [
-                                            "type",
-                                            "value"
-                                        ]
+                                        "required": ["type", "value"]
                                     }
                                 },
                                 "glob": {
@@ -84,10 +91,7 @@
                                     "type": "boolean"
                                 }
                             },
-                            "required": [
-                                "path",
-                                "redactions"
-                            ]
+                            "required": ["path", "redactions"]
                         }
                     }
                 }
@@ -120,9 +124,7 @@
                                     "type": "boolean"
                                 }
                             },
-                            "required": [
-                                "path"
-                            ]
+                            "required": ["path"]
                         }
                     },
                     "glob": {
@@ -130,9 +132,7 @@
                         "type": "boolean"
                     }
                 },
-                "required": [
-                    "host"
-                ]
+                "required": ["host"]
             }
         }
     },
@@ -143,6 +143,7 @@
         "http_whitelist_enabled",
         "wp_rest_logging_enabled",
         "wp_http_client_logging_enabled",
+        "wp_user_event_logging_enabled",
         "http_redactions",
         "http_whitelist"
     ]

--- a/src/Lolly/Config/Config.php
+++ b/src/Lolly/Config/Config.php
@@ -56,6 +56,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *      http_whitelist_enabled: bool,
  *      wp_rest_logging_enabled: bool,
  *      wp_http_client_logging_enabled: bool,
+ *      wp_user_event_logging_enabled: bool,
  *      http_redactions: array<HttpHostRedactions>,
  *      http_whitelist: array<HttpHostWhitelist>,
  *  }
@@ -140,6 +141,17 @@ class Config implements RedactorConfig, WhitelistConfig {
         }
 
         return $this->http_logging_config['wp_http_client_logging_enabled'] ?? false;
+    }
+
+    /**
+     * Whether user event logging is enabled.
+     */
+    public function is_wp_user_event_logging_enabled(): bool {
+        if ( ! $this->is_logging_enabled() ) {
+            return false;
+        }
+
+        return $this->http_logging_config['wp_user_event_logging_enabled'] ?? false;
     }
 
     /**
@@ -343,6 +355,7 @@ class Config implements RedactorConfig, WhitelistConfig {
                     'enabled'                        => false,
                     'wp_rest_logging_enabled'        => true,
                     'wp_http_client_logging_enabled' => true,
+                    'wp_user_event_logging_enabled'  => true,
                     'http_redactions_enabled'        => true,
                     'http_whitelist_enabled'         => false,
                     'http_redactions'                => [],

--- a/src/Lolly/Listeners/LogOnUserCreated.php
+++ b/src/Lolly/Listeners/LogOnUserCreated.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lolly\Listeners;
+
+use Lolly\Psr\Log\LoggerInterface;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * LogOnUserCreated class.
+ *
+ * Log when a new user is created in WordPress.
+ *
+ * @package Lolly
+ */
+class LogOnUserCreated {
+
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    /**
+     * Handle the user_register action.
+     *
+     * @param int                  $user_id   User ID.
+     * @param array<string, mixed> $_userdata The raw array of data passed to wp_insert_user().
+     */
+    public function handle( int $user_id, array $_userdata ): void {
+        $user  = get_userdata( $user_id );
+        $roles = $user instanceof \WP_User ? $user->roles : [];
+
+        $this->logger->info(
+            'User created.',
+            [
+                'target_user' => [ 'id' => $user_id ],
+                'roles'       => $roles,
+            ]
+        );
+    }
+}

--- a/src/Lolly/Listeners/LogOnUserDeleted.php
+++ b/src/Lolly/Listeners/LogOnUserDeleted.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lolly\Listeners;
+
+use Lolly\Psr\Log\LoggerInterface;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * LogOnUserDeleted class.
+ *
+ * Log when a user is deleted from WordPress.
+ *
+ * @package Lolly
+ */
+class LogOnUserDeleted {
+
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    /**
+     * Handle the delete_user action.
+     *
+     * Fires immediately before a user is deleted from the database.
+     *
+     * @param int      $user_id  ID of the user to delete.
+     * @param int|null $reassign ID of the user to reassign posts and links to.
+     * @param \WP_User $user     WP_User object of the user to delete.
+     */
+    public function handle( int $user_id, ?int $reassign, \WP_User $user ): void {
+        $context = [
+            'target_user' => [ 'id' => $user_id ],
+            'roles'       => $user->roles,
+        ];
+
+        if ( $reassign !== null ) {
+            $context['reassign_to'] = [ 'id' => $reassign ];
+        }
+
+        $this->logger->info( 'User deleted.', $context );
+    }
+}

--- a/src/Lolly/Listeners/LogOnUserRoleAdded.php
+++ b/src/Lolly/Listeners/LogOnUserRoleAdded.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lolly\Listeners;
+
+use Lolly\Psr\Log\LoggerInterface;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * LogOnUserRoleAdded class.
+ *
+ * Log when a role is added to a user in WordPress.
+ *
+ * @package Lolly
+ */
+class LogOnUserRoleAdded {
+
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    /**
+     * Handle the add_user_role action.
+     *
+     * Fires after a role has been added to a user.
+     *
+     * @param int    $user_id The user ID.
+     * @param string $role    The added role.
+     */
+    public function handle( int $user_id, string $role ): void {
+        $this->logger->info(
+            'User role added.',
+            [
+                'target_user' => [ 'id' => $user_id ],
+                'role'        => $role,
+            ]
+        );
+    }
+}

--- a/src/Lolly/Listeners/LogOnUserRoleChanged.php
+++ b/src/Lolly/Listeners/LogOnUserRoleChanged.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lolly\Listeners;
+
+use Lolly\Psr\Log\LoggerInterface;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * LogOnUserRoleChanged class.
+ *
+ * Log when a user's role is changed in WordPress.
+ *
+ * @package Lolly
+ */
+class LogOnUserRoleChanged {
+
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    /**
+     * Handle the set_user_role action.
+     *
+     * Fires after the user's role has changed.
+     *
+     * @param int      $user_id   The user ID.
+     * @param string   $role      The new role.
+     * @param string[] $old_roles An array of the user's previous roles.
+     */
+    public function handle( int $user_id, string $role, array $old_roles ): void {
+        $this->logger->info(
+            'User role changed.',
+            [
+                'target_user' => [ 'id' => $user_id ],
+                'role'        => $role,
+                'old_roles'   => $old_roles,
+            ]
+        );
+    }
+}

--- a/src/Lolly/Listeners/LogOnUserRoleRemoved.php
+++ b/src/Lolly/Listeners/LogOnUserRoleRemoved.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lolly\Listeners;
+
+use Lolly\Psr\Log\LoggerInterface;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * LogOnUserRoleRemoved class.
+ *
+ * Log when a role is removed from a user in WordPress.
+ *
+ * @package Lolly
+ */
+class LogOnUserRoleRemoved {
+
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    /**
+     * Handle the remove_user_role action.
+     *
+     * Fires after a role has been removed from a user.
+     *
+     * @param int    $user_id The user ID.
+     * @param string $role    The removed role.
+     */
+    public function handle( int $user_id, string $role ): void {
+        $this->logger->info(
+            'User role removed.',
+            [
+                'target_user' => [ 'id' => $user_id ],
+                'role'        => $role,
+            ]
+        );
+    }
+}

--- a/src/Lolly/Listeners/Provider.php
+++ b/src/Lolly/Listeners/Provider.php
@@ -27,6 +27,11 @@ class Provider extends ServiceProvider {
     public array $provides = [
         LogOnHttpClientRequest::class,
         LogOnRestApiRequest::class,
+        LogOnUserCreated::class,
+        LogOnUserDeleted::class,
+        LogOnUserRoleAdded::class,
+        LogOnUserRoleChanged::class,
+        LogOnUserRoleRemoved::class,
     ];
 
     public function register() {
@@ -38,7 +43,20 @@ class Provider extends ServiceProvider {
             add_filter( 'rest_post_dispatch', $this->container->callback( LogOnRestApiRequest::class, 'handle' ), 999, 3 );
         }
 
+        if ( $this->config->is_wp_user_event_logging_enabled() ) {
+            add_action( 'user_register', $this->container->callback( LogOnUserCreated::class, 'handle' ), 10, 2 );
+            add_action( 'delete_user', $this->container->callback( LogOnUserDeleted::class, 'handle' ), 10, 3 );
+            add_action( 'add_user_role', $this->container->callback( LogOnUserRoleAdded::class, 'handle' ), 10, 2 );
+            add_action( 'set_user_role', $this->container->callback( LogOnUserRoleChanged::class, 'handle' ), 10, 3 );
+            add_action( 'remove_user_role', $this->container->callback( LogOnUserRoleRemoved::class, 'handle' ), 10, 2 );
+        }
+
         $this->container->bind( LogOnHttpClientRequest::class, LogOnHttpClientRequest::class );
         $this->container->bind( LogOnRestApiRequest::class, LogOnRestApiRequest::class );
+        $this->container->bind( LogOnUserCreated::class, LogOnUserCreated::class );
+        $this->container->bind( LogOnUserDeleted::class, LogOnUserDeleted::class );
+        $this->container->bind( LogOnUserRoleAdded::class, LogOnUserRoleAdded::class );
+        $this->container->bind( LogOnUserRoleChanged::class, LogOnUserRoleChanged::class );
+        $this->container->bind( LogOnUserRoleRemoved::class, LogOnUserRoleRemoved::class );
     }
 }

--- a/src/Lolly/Processors/WpUserProcessor.php
+++ b/src/Lolly/Processors/WpUserProcessor.php
@@ -27,7 +27,7 @@ class WpUserProcessor implements ProcessorInterface {
         $extra   = $record->extra;
 
         foreach ( $context as $key => $value ) {
-            if ( $value instanceof Wp_User && $value->exists() ) {
+            if ( $value instanceof WP_User && $value->exists() ) {
                 $user_fields = [
                     'id' => $value->ID,
                 ];

--- a/tests/Support/Helper/Lolly.php
+++ b/tests/Support/Helper/Lolly.php
@@ -24,9 +24,6 @@ class Lolly extends Module {
     public function _after( TestInterface $test ): void {
         delete_option( Config::OPTION_SLUG );
 
-        remove_all_actions( 'http_api_debug' );
-        remove_all_filters( 'rest_post_dispatch' );
-
         if ( $this->loggerFaked ) {
             $this->restoreLogger();
         }
@@ -78,6 +75,7 @@ class Lolly extends Module {
             'enabled'                        => false,
             'wp_http_client_logging_enabled' => false,
             'wp_rest_logging_enabled'        => false,
+            'wp_user_event_logging_enabled'  => false,
             'http_redactions_enabled'        => false,
             'http_whitelist_enabled'         => false,
             'http_redactions'                => [],

--- a/tests/Support/WpunitTester.php
+++ b/tests/Support/WpunitTester.php
@@ -28,7 +28,7 @@ class WpunitTester extends \Codeception\Actor {
      *
      * @return \WP_User The created user
      */
-    public function login_as_admin() {
+    public function loginAsAdmin() {
         $user_id = $this->factory()->user->create(
             [
                 'role' => 'administrator',
@@ -47,7 +47,7 @@ class WpunitTester extends \Codeception\Actor {
      * @param string $role The user role.
      * @return \WP_User The created user
      */
-    public function login_as_role( string $role = 'subscriber' ) {
+    public function loginAsRole( string $role = 'subscriber' ) {
         $user_id = $this->factory()->user->create(
             [
                 'role' => $role,

--- a/tests/Wpunit/Listeners/LogOnHttpClientRequestTest.php
+++ b/tests/Wpunit/Listeners/LogOnHttpClientRequestTest.php
@@ -35,6 +35,12 @@ class LogOnHttpClientRequestTest extends WPTestCase {
         );
     }
 
+    public function _after(): void {
+        remove_all_actions( 'http_api_debug' );
+
+        parent::_after();
+    }
+
     public function testLogsSuccessfulHttpRequest(): void {
         $response = $this->buildResponse( 200, '{"success": true}' );
 

--- a/tests/Wpunit/Listeners/LogOnRestApiRequestTest.php
+++ b/tests/Wpunit/Listeners/LogOnRestApiRequestTest.php
@@ -48,6 +48,8 @@ class LogOnRestApiRequestTest extends WPTestCase {
     public function _after(): void {
         $_SERVER = $this->originalServer;
 
+        remove_all_filters( 'rest_post_dispatch' );
+
         parent::_after();
     }
 

--- a/tests/Wpunit/Listeners/LogOnUserCreatedTest.php
+++ b/tests/Wpunit/Listeners/LogOnUserCreatedTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wpunit\Listeners;
+
+use Lolly\Listeners\LogOnUserCreated;
+use lucatume\WPBrowser\TestCase\WPTestCase;
+use Tests\Support\WpunitTester;
+
+/**
+ * @property WpunitTester $tester
+ */
+class LogOnUserCreatedTest extends WPTestCase {
+    public function _before(): void {
+        parent::_before();
+
+        $this->tester->updateSettings(
+            [
+                'enabled'                       => true,
+                'wp_user_event_logging_enabled' => true,
+            ]
+        );
+
+        add_action(
+            'user_register',
+            lolly()->callback( LogOnUserCreated::class, 'handle' ),
+            10,
+            2
+        );
+    }
+
+    public function _after(): void {
+        remove_all_actions( 'user_register' );
+
+        parent::_after();
+    }
+
+    public function testLogsUserCreation(): void {
+        $this->tester->fakeLogger();
+
+        wp_insert_user(
+            [
+                'user_login' => 'testuser',
+                'user_pass'  => 'password123',
+                'user_email' => 'test@example.com',
+                'role'       => 'subscriber',
+            ]
+        );
+
+        $this->tester->seeLogMessage( 'User created.', 'info' );
+    }
+
+    public function testCapturesTargetUserIdAndRoles(): void {
+        $this->tester->fakeLogger();
+
+        $user_id = wp_insert_user(
+            [
+                'user_login' => 'targetuser',
+                'user_pass'  => 'password123',
+                'user_email' => 'target@example.com',
+                'role'       => 'editor',
+            ]
+        );
+
+        $records = $this->tester->grabLogRecords();
+        $this->assertCount( 1, $records );
+
+        $context = $records[0]->context;
+        $this->assertArrayHasKey( 'target_user', $context );
+        $this->assertIsArray( $context['target_user'] );
+        $this->assertEquals( $user_id, $context['target_user']['id'] );
+        $this->assertArrayHasKey( 'roles', $context );
+        $this->assertContains( 'editor', $context['roles'] );
+    }
+
+    public function testCapturesActorInExtra(): void {
+        $admin = $this->tester->loginAsAdmin();
+
+        $this->tester->fakeLogger();
+
+        wp_insert_user(
+            [
+                'user_login' => 'newuser',
+                'user_pass'  => 'password123',
+                'user_email' => 'new@example.com',
+                'role'       => 'subscriber',
+            ]
+        );
+
+        $records = $this->tester->grabLogRecords();
+        $this->assertCount( 1, $records );
+
+        $extra = $records[0]->extra;
+        $this->assertArrayHasKey( 'user', $extra );
+        $this->assertEquals( $admin->ID, $extra['user']['id'] );
+    }
+}

--- a/tests/Wpunit/Listeners/LogOnUserDeletedTest.php
+++ b/tests/Wpunit/Listeners/LogOnUserDeletedTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wpunit\Listeners;
+
+use Lolly\Listeners\LogOnUserDeleted;
+use lucatume\WPBrowser\TestCase\WPTestCase;
+use Tests\Support\WpunitTester;
+
+/**
+ * @property WpunitTester $tester
+ */
+class LogOnUserDeletedTest extends WPTestCase {
+    public function _before(): void {
+        parent::_before();
+
+        $this->tester->updateSettings(
+            [
+                'enabled'                       => true,
+                'wp_user_event_logging_enabled' => true,
+            ]
+        );
+
+        add_action(
+            'delete_user',
+            lolly()->callback( LogOnUserDeleted::class, 'handle' ),
+            10,
+            3
+        );
+    }
+
+    public function _after(): void {
+        remove_all_actions( 'delete_user' );
+
+        parent::_after();
+    }
+
+    public function testLogsUserDeletion(): void {
+        $user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+
+        $this->tester->fakeLogger();
+
+        wp_delete_user( $user_id );
+
+        $this->tester->seeLogMessage( 'User deleted.', 'info' );
+    }
+
+    public function testCapturesTargetUserIdAndRoles(): void {
+        $user_id = self::factory()->user->create( [ 'role' => 'editor' ] );
+
+        $this->tester->fakeLogger();
+
+        wp_delete_user( $user_id );
+
+        $records = $this->tester->grabLogRecords();
+        $this->assertCount( 1, $records );
+
+        $context = $records[0]->context;
+        $this->assertArrayHasKey( 'target_user', $context );
+        $this->assertIsArray( $context['target_user'] );
+        $this->assertEquals( $user_id, $context['target_user']['id'] );
+        $this->assertArrayHasKey( 'roles', $context );
+        $this->assertContains( 'editor', $context['roles'] );
+    }
+
+    public function testCapturesActorInExtra(): void {
+        $admin   = $this->tester->loginAsAdmin();
+        $user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+
+        $this->tester->fakeLogger();
+
+        wp_delete_user( $user_id );
+
+        $records = $this->tester->grabLogRecords();
+        $this->assertCount( 1, $records );
+
+        $extra = $records[0]->extra;
+        $this->assertArrayHasKey( 'user', $extra );
+        $this->assertEquals( $admin->ID, $extra['user']['id'] );
+    }
+
+    public function testCapturesReassignUserId(): void {
+        $this->tester->loginAsAdmin();
+
+        $user_id     = self::factory()->user->create( [ 'role' => 'author' ] );
+        $reassign_id = self::factory()->user->create( [ 'role' => 'editor' ] );
+
+        $this->tester->fakeLogger();
+
+        wp_delete_user( $user_id, $reassign_id );
+
+        $records = $this->tester->grabLogRecords();
+        $this->assertCount( 1, $records );
+
+        $context = $records[0]->context;
+        $this->assertArrayHasKey( 'reassign_to', $context );
+        $this->assertIsArray( $context['reassign_to'] );
+        $this->assertEquals( $reassign_id, $context['reassign_to']['id'] );
+    }
+}

--- a/tests/Wpunit/Listeners/LogOnUserRoleAddedTest.php
+++ b/tests/Wpunit/Listeners/LogOnUserRoleAddedTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wpunit\Listeners;
+
+use Lolly\Listeners\LogOnUserRoleAdded;
+use lucatume\WPBrowser\TestCase\WPTestCase;
+use Tests\Support\WpunitTester;
+
+/**
+ * @property WpunitTester $tester
+ */
+class LogOnUserRoleAddedTest extends WPTestCase {
+    public function _before(): void {
+        parent::_before();
+
+        $this->tester->updateSettings(
+            [
+                'enabled'                       => true,
+                'wp_user_event_logging_enabled' => true,
+            ]
+        );
+
+        add_action(
+            'add_user_role',
+            lolly()->callback( LogOnUserRoleAdded::class, 'handle' ),
+            10,
+            2
+        );
+    }
+
+    public function _after(): void {
+        remove_all_actions( 'add_user_role' );
+
+        parent::_after();
+    }
+
+    public function testLogsRoleAdded(): void {
+        $user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+        $user    = get_userdata( $user_id );
+
+        $this->tester->fakeLogger();
+
+        $user->add_role( 'editor' );
+
+        $this->tester->seeLogMessage( 'User role added.', 'info' );
+    }
+
+    public function testCapturesTargetUserIdAndRole(): void {
+        $user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+        $user    = get_userdata( $user_id );
+
+        $this->tester->fakeLogger();
+
+        $user->add_role( 'author' );
+
+        $records = $this->tester->grabLogRecords();
+        $this->assertCount( 1, $records );
+
+        $context = $records[0]->context;
+        $this->assertArrayHasKey( 'target_user', $context );
+        $this->assertIsArray( $context['target_user'] );
+        $this->assertEquals( $user_id, $context['target_user']['id'] );
+        $this->assertArrayHasKey( 'role', $context );
+        $this->assertEquals( 'author', $context['role'] );
+    }
+
+    public function testCapturesActorInExtra(): void {
+        $admin   = $this->tester->loginAsAdmin();
+        $user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+        $user    = get_userdata( $user_id );
+
+        $this->tester->fakeLogger();
+
+        $user->add_role( 'contributor' );
+
+        $records = $this->tester->grabLogRecords();
+        $this->assertCount( 1, $records );
+
+        $extra = $records[0]->extra;
+        $this->assertArrayHasKey( 'user', $extra );
+        $this->assertEquals( $admin->ID, $extra['user']['id'] );
+    }
+}

--- a/tests/Wpunit/Listeners/LogOnUserRoleChangedTest.php
+++ b/tests/Wpunit/Listeners/LogOnUserRoleChangedTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wpunit\Listeners;
+
+use Lolly\Listeners\LogOnUserRoleChanged;
+use lucatume\WPBrowser\TestCase\WPTestCase;
+use Tests\Support\WpunitTester;
+
+/**
+ * @property WpunitTester $tester
+ */
+class LogOnUserRoleChangedTest extends WPTestCase {
+    public function _before(): void {
+        parent::_before();
+
+        $this->tester->updateSettings(
+            [
+                'enabled'                       => true,
+                'wp_user_event_logging_enabled' => true,
+            ]
+        );
+
+        add_action(
+            'set_user_role',
+            lolly()->callback( LogOnUserRoleChanged::class, 'handle' ),
+            10,
+            3
+        );
+    }
+
+    public function _after(): void {
+        remove_all_actions( 'set_user_role' );
+
+        parent::_after();
+    }
+
+    public function testLogsRoleChange(): void {
+        $user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+        $user    = get_userdata( $user_id );
+
+        $this->tester->fakeLogger();
+
+        $user->set_role( 'editor' );
+
+        $this->tester->seeLogMessage( 'User role changed.', 'info' );
+    }
+
+    public function testCapturesTargetUserIdAndRoles(): void {
+        $user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+        $user    = get_userdata( $user_id );
+
+        $this->tester->fakeLogger();
+
+        $user->set_role( 'author' );
+
+        $records = $this->tester->grabLogRecords();
+        $this->assertCount( 1, $records );
+
+        $context = $records[0]->context;
+        $this->assertArrayHasKey( 'target_user', $context );
+        $this->assertIsArray( $context['target_user'] );
+        $this->assertEquals( $user_id, $context['target_user']['id'] );
+        $this->assertArrayHasKey( 'role', $context );
+        $this->assertArrayHasKey( 'old_roles', $context );
+        $this->assertEquals( 'author', $context['role'] );
+        $this->assertContains( 'subscriber', $context['old_roles'] );
+    }
+
+    public function testCapturesActorInExtra(): void {
+        $admin   = $this->tester->loginAsAdmin();
+        $user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+        $user    = get_userdata( $user_id );
+
+        $this->tester->fakeLogger();
+
+        $user->set_role( 'editor' );
+
+        $records = $this->tester->grabLogRecords();
+        $this->assertCount( 1, $records );
+
+        $extra = $records[0]->extra;
+        $this->assertArrayHasKey( 'user', $extra );
+        $this->assertEquals( $admin->ID, $extra['user']['id'] );
+    }
+}

--- a/tests/Wpunit/Listeners/LogOnUserRoleRemovedTest.php
+++ b/tests/Wpunit/Listeners/LogOnUserRoleRemovedTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wpunit\Listeners;
+
+use Lolly\Listeners\LogOnUserRoleRemoved;
+use lucatume\WPBrowser\TestCase\WPTestCase;
+use Tests\Support\WpunitTester;
+
+/**
+ * @property WpunitTester $tester
+ */
+class LogOnUserRoleRemovedTest extends WPTestCase {
+    public function _before(): void {
+        parent::_before();
+
+        $this->tester->updateSettings(
+            [
+                'enabled'                       => true,
+                'wp_user_event_logging_enabled' => true,
+            ]
+        );
+
+        add_action(
+            'remove_user_role',
+            lolly()->callback( LogOnUserRoleRemoved::class, 'handle' ),
+            10,
+            2
+        );
+    }
+
+    public function _after(): void {
+        remove_all_actions( 'remove_user_role' );
+
+        parent::_after();
+    }
+
+    public function testLogsRoleRemoved(): void {
+        $user_id = self::factory()->user->create( [ 'role' => 'editor' ] );
+        $user    = get_userdata( $user_id );
+        $user->add_role( 'author' );
+
+        $this->tester->fakeLogger();
+
+        $user->remove_role( 'author' );
+
+        $this->tester->seeLogMessage( 'User role removed.', 'info' );
+    }
+
+    public function testCapturesTargetUserIdAndRole(): void {
+        $user_id = self::factory()->user->create( [ 'role' => 'editor' ] );
+        $user    = get_userdata( $user_id );
+        $user->add_role( 'contributor' );
+
+        $this->tester->fakeLogger();
+
+        $user->remove_role( 'contributor' );
+
+        $records = $this->tester->grabLogRecords();
+        $this->assertCount( 1, $records );
+
+        $context = $records[0]->context;
+        $this->assertArrayHasKey( 'target_user', $context );
+        $this->assertIsArray( $context['target_user'] );
+        $this->assertEquals( $user_id, $context['target_user']['id'] );
+        $this->assertArrayHasKey( 'role', $context );
+        $this->assertEquals( 'contributor', $context['role'] );
+    }
+
+    public function testCapturesActorInExtra(): void {
+        $admin   = $this->tester->loginAsAdmin();
+        $user_id = self::factory()->user->create( [ 'role' => 'editor' ] );
+        $user    = get_userdata( $user_id );
+        $user->add_role( 'author' );
+
+        $this->tester->fakeLogger();
+
+        $user->remove_role( 'author' );
+
+        $records = $this->tester->grabLogRecords();
+        $this->assertCount( 1, $records );
+
+        $extra = $records[0]->extra;
+        $this->assertArrayHasKey( 'user', $extra );
+        $this->assertEquals( $admin->ID, $extra['user']['id'] );
+    }
+}

--- a/tests/Wpunit/Rest/SettingsTest.php
+++ b/tests/Wpunit/Rest/SettingsTest.php
@@ -14,7 +14,7 @@ class SettingsTest extends WPRestApiTestCase {
     public function setUp(): void {
         parent::setUp();
 
-        $this->tester->login_as_admin();
+        $this->tester->loginAsAdmin();
 
         do_action( 'rest_api_init' );
 
@@ -56,7 +56,7 @@ class SettingsTest extends WPRestApiTestCase {
 
     public function testNonAdminCannotAccessEndpoint(): void {
         $this->tester->logout();
-        $this->tester->login_as_role( 'subscriber' );
+        $this->tester->loginAsRole( 'subscriber' );
 
         $request  = new WP_REST_Request( 'GET', '/wp/v2/settings' );
         $response = rest_do_request( $request );
@@ -95,6 +95,7 @@ class SettingsTest extends WPRestApiTestCase {
                 'enabled'                        => true,
                 'wp_rest_logging_enabled'        => false,
                 'wp_http_client_logging_enabled' => false,
+                'wp_user_event_logging_enabled'  => false,
                 'http_redactions_enabled'        => false,
                 'http_whitelist_enabled'         => true,
                 'http_redactions'                => [


### PR DESCRIPTION
Lolly can now log WordPress user lifecycle events for auditing purposes.
A new toggle in the settings page controls user event logging independently
from HTTP logging.

Events captured include user creation, deletion, and role changes (set, add,
remove). Each log entry includes the target user, relevant role information,
and the actor who performed the action when applicable.