### PR TITLE
feat: add authentication event logging

### DIFF
--- a/config/default-logging-config.json
+++ b/config/default-logging-config.json
@@ -7,6 +7,15 @@
     "wp_rest_logging_enabled": true,
     "wp_http_client_logging_enabled": true,
     "wp_user_event_logging_enabled": true,
+    "wp_auth_logging_enabled": true,
+    "wp_auth_logging_config": {
+        "login": true,
+        "logout": true,
+        "login_failed": false,
+        "password_changed": true,
+        "app_password_created": true,
+        "app_password_deleted": true
+    },
     "http_redactions": [
         {
             "host": "*",

--- a/docs/auth-event-logging.md
+++ b/docs/auth-event-logging.md
@@ -1,0 +1,116 @@
+# Authentication Event Logging
+
+Lolly can log WordPress authentication events for security monitoring and access auditing. This feature is controlled by the **Authentication Logging** toggle in the settings page, with individual event types configurable in the **Authentication Events** card.
+
+## Events Captured
+
+### User Logged In
+
+Logged when a user successfully authenticates.
+
+**Hook:** `wp_login`
+
+**Logged data:**
+- Target user ID
+- Actor (same as target for self-login)
+
+### User Logged Out
+
+Logged when a user ends their session.
+
+**Hook:** `wp_logout`
+
+**Logged data:**
+- Target user ID
+- Actor (same as target for self-logout)
+
+### Login Failed
+
+Logged when a login attempt fails. **Disabled by default** due to potential high volume on sites under attack.
+
+**Hook:** `wp_login_failed`
+
+**Log level:** `warning`
+
+**Logged data:**
+- Username attempted
+- WP_Error with failure reason
+
+### Password Reset
+
+Logged when a user's password is reset via the password reset flow.
+
+**Hook:** `after_password_reset`
+
+**Logged data:**
+- Target user ID
+- Actor (admin who initiated reset, if applicable)
+
+### Password Changed
+
+Logged when a user's password is changed via profile update.
+
+**Hook:** `profile_update`
+
+**Logged data:**
+- Target user ID
+- Actor (admin who made the change, if different from target)
+
+### Application Password Created
+
+Logged when an application password is generated for a user.
+
+**Hook:** `wp_create_application_password`
+
+**Logged data:**
+- Target user ID
+- Application name
+- Application UUID
+- Actor (admin who created it, if different from target)
+
+Note: The actual password value is never logged.
+
+### Application Password Deleted
+
+Logged when an application password is revoked.
+
+**Hook:** `wp_delete_application_password`
+
+**Logged data:**
+- Target user ID
+- Application name
+- Application UUID
+- Actor (admin who deleted it, if different from target)
+
+## Log Format
+
+Events are logged at `info` level (except login failures which use `warning`) with ECS-compatible formatting:
+
+```json
+{
+  "@timestamp": "2026-01-23T10:00:00.000Z",
+  "message": "User logged in.",
+  "log.level": "info",
+  "user": { "id": 5 },
+  "ctxt_target_user": { "id": 5 }
+}
+```
+
+The `user` field contains the actor (who performed the action). The `target_user` field contains the affected user.
+
+## Configuration
+
+Enable or disable via **Settings > Lolly Log > Authentication Logging**.
+
+When enabled, the **Authentication Events** card appears with toggles for each event type:
+
+| Event | Default |
+|-------|---------|
+| Login | Enabled |
+| Logout | Enabled |
+| Login Failed | Disabled |
+| Password Changed | Enabled |
+| Application Password Created | Enabled |
+| Application Password Deleted | Enabled |
+
+Login failures are disabled by default because sites under brute-force attack can generate extremely high log volume. Consider your log storage capacity before enabling.

--- a/resources/js/components/settings-page.tsx
+++ b/resources/js/components/settings-page.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 
 import {
     Button,
@@ -14,6 +14,16 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 import { store as settingStore } from '../settings/store';
+import type { AuthLoggingConfig } from '../types';
+
+const defaultAuthConfig: AuthLoggingConfig = {
+    login: true,
+    logout: true,
+    login_failed: false,
+    password_changed: true,
+    app_password_created: true,
+    app_password_deleted: true,
+};
 
 export default function SettingsPage(): React.ReactNode {
     const { settings, isSaving, editError } = useSelect(
@@ -27,11 +37,27 @@ export default function SettingsPage(): React.ReactNode {
 
     const { editSetting, saveEditedSettings } = useDispatch(settingStore);
 
+    const editAuthConfig = useCallback(
+        (key: keyof AuthLoggingConfig, value: boolean) => {
+            const currentConfig =
+                settings?.wp_auth_logging_config ?? defaultAuthConfig;
+            editSetting('wp_auth_logging_config', {
+                ...currentConfig,
+                [key]: value,
+            });
+        },
+        [settings?.wp_auth_logging_config, editSetting]
+    );
+
     // Note: The Lolly settings are preloaded, though still has to go through
     // resolution because `apiFetch` returns a promise.
     if (!settings) {
         return null;
     }
+
+    const authConfig = settings.wp_auth_logging_config ?? defaultAuthConfig;
+    const authEventsDisabled =
+        !settings.enabled || !settings.wp_auth_logging_enabled;
 
     return (
         <VStack spacing={4}>
@@ -104,6 +130,19 @@ export default function SettingsPage(): React.ReactNode {
                             __nextHasNoMarginBottom
                         />
                         <ToggleControl
+                            label={__('Authentication Logging', 'lolly')}
+                            checked={settings.wp_auth_logging_enabled}
+                            onChange={(value: boolean) =>
+                                editSetting('wp_auth_logging_enabled', value)
+                            }
+                            disabled={!settings.enabled}
+                            help={__(
+                                'Log authentication events. Configure which events below.',
+                                'lolly'
+                            )}
+                            __nextHasNoMarginBottom
+                        />
+                        <ToggleControl
                             label={__('HTTP Redactions', 'lolly')}
                             checked={settings.http_redactions_enabled}
                             onChange={(value: boolean) =>
@@ -132,6 +171,107 @@ export default function SettingsPage(): React.ReactNode {
                     </VStack>
                 </CardBody>
             </Card>
+
+            {settings.wp_auth_logging_enabled && (
+                <Card>
+                    <CardHeader>
+                        <h2 style={{ margin: 0 }}>
+                            {__('Authentication Events', 'lolly')}
+                        </h2>
+                    </CardHeader>
+                    <CardBody>
+                        <VStack spacing={4}>
+                            <ToggleControl
+                                label={__('Login', 'lolly')}
+                                checked={authConfig.login}
+                                onChange={(value: boolean) =>
+                                    editAuthConfig('login', value)
+                                }
+                                disabled={authEventsDisabled}
+                                help={__(
+                                    'Log successful user logins.',
+                                    'lolly'
+                                )}
+                                __nextHasNoMarginBottom
+                            />
+                            <ToggleControl
+                                label={__('Logout', 'lolly')}
+                                checked={authConfig.logout}
+                                onChange={(value: boolean) =>
+                                    editAuthConfig('logout', value)
+                                }
+                                disabled={authEventsDisabled}
+                                help={__('Log user logouts.', 'lolly')}
+                                __nextHasNoMarginBottom
+                            />
+                            <ToggleControl
+                                label={__('Login Failed', 'lolly')}
+                                checked={authConfig.login_failed}
+                                onChange={(value: boolean) =>
+                                    editAuthConfig('login_failed', value)
+                                }
+                                disabled={authEventsDisabled}
+                                help={__(
+                                    'Log failed login attempts. May generate high volume on sites under attack.',
+                                    'lolly'
+                                )}
+                                __nextHasNoMarginBottom
+                            />
+                            <ToggleControl
+                                label={__('Password Changed', 'lolly')}
+                                checked={authConfig.password_changed}
+                                onChange={(value: boolean) =>
+                                    editAuthConfig('password_changed', value)
+                                }
+                                disabled={authEventsDisabled}
+                                help={__(
+                                    'Log password changes and resets.',
+                                    'lolly'
+                                )}
+                                __nextHasNoMarginBottom
+                            />
+                            <ToggleControl
+                                label={__(
+                                    'Application Password Created',
+                                    'lolly'
+                                )}
+                                checked={authConfig.app_password_created}
+                                onChange={(value: boolean) =>
+                                    editAuthConfig(
+                                        'app_password_created',
+                                        value
+                                    )
+                                }
+                                disabled={authEventsDisabled}
+                                help={__(
+                                    'Log when application passwords are created.',
+                                    'lolly'
+                                )}
+                                __nextHasNoMarginBottom
+                            />
+                            <ToggleControl
+                                label={__(
+                                    'Application Password Deleted',
+                                    'lolly'
+                                )}
+                                checked={authConfig.app_password_deleted}
+                                onChange={(value: boolean) =>
+                                    editAuthConfig(
+                                        'app_password_deleted',
+                                        value
+                                    )
+                                }
+                                disabled={authEventsDisabled}
+                                help={__(
+                                    'Log when application passwords are deleted.',
+                                    'lolly'
+                                )}
+                                __nextHasNoMarginBottom
+                            />
+                        </VStack>
+                    </CardBody>
+                </Card>
+            )}
 
             <HStack>
                 <Button

--- a/resources/js/types.ts
+++ b/resources/js/types.ts
@@ -26,12 +26,24 @@ export interface HttpWhitelistSet {
     glob?: boolean;
 }
 
+export interface AuthLoggingConfig {
+    login: boolean;
+    logout: boolean;
+    login_failed: boolean;
+    password_changed: boolean;
+    app_password_created: boolean;
+    app_password_deleted: boolean;
+}
+
 export interface Settings {
     enabled: boolean;
     http_redactions_enabled: boolean;
     http_whitelist_enabled: boolean;
     wp_rest_logging_enabled: boolean;
     wp_http_client_logging_enabled: boolean;
+    wp_user_event_logging_enabled: boolean;
+    wp_auth_logging_enabled: boolean;
+    wp_auth_logging_config: AuthLoggingConfig;
     http_redactions: HttpRedactionSet[];
     http_whitelist: HttpWhitelistSet[];
 }

--- a/resources/schemas/http-logging-config.json
+++ b/resources/schemas/http-logging-config.json
@@ -25,6 +25,48 @@
             "description": "Whether user event logging is enabled (creation, deletion, role changes).",
             "type": "boolean"
         },
+        "wp_auth_logging_enabled": {
+            "description": "Whether authentication event logging is enabled (login, logout, password changes).",
+            "type": "boolean"
+        },
+        "wp_auth_logging_config": {
+            "description": "Configuration for individual authentication events to log.",
+            "type": "object",
+            "properties": {
+                "login": {
+                    "description": "Log successful user logins.",
+                    "type": "boolean"
+                },
+                "logout": {
+                    "description": "Log user logouts.",
+                    "type": "boolean"
+                },
+                "login_failed": {
+                    "description": "Log failed login attempts.",
+                    "type": "boolean"
+                },
+                "password_changed": {
+                    "description": "Log password changes and resets.",
+                    "type": "boolean"
+                },
+                "app_password_created": {
+                    "description": "Log application password creation.",
+                    "type": "boolean"
+                },
+                "app_password_deleted": {
+                    "description": "Log application password deletion.",
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "login",
+                "logout",
+                "login_failed",
+                "password_changed",
+                "app_password_created",
+                "app_password_deleted"
+            ]
+        },
         "http_redactions_enabled": {
             "description": "Whether the HTTP logging redaction feature is enabled.",
             "type": "boolean"
@@ -144,6 +186,8 @@
         "wp_rest_logging_enabled",
         "wp_http_client_logging_enabled",
         "wp_user_event_logging_enabled",
+        "wp_auth_logging_enabled",
+        "wp_auth_logging_config",
         "http_redactions",
         "http_whitelist"
     ]

--- a/src/Lolly/Config/Config.php
+++ b/src/Lolly/Config/Config.php
@@ -49,14 +49,25 @@ if ( ! defined( 'ABSPATH' ) ) {
  *      glob?: bool
  * }
  *
+ * @phpstan-type AuthLoggingConfig array{
+ *      login?: bool,
+ *      logout?: bool,
+ *      login_failed?: bool,
+ *      password_changed?: bool,
+ *      app_password_created?: bool,
+ *      app_password_deleted?: bool
+ * }
+ *
  * @phpstan-type HttpLoggingConfig array{
- *      verion: int,
+ *      version: int,
  *      enabled: bool,
  *      http_redactions_enabled: bool,
  *      http_whitelist_enabled: bool,
  *      wp_rest_logging_enabled: bool,
  *      wp_http_client_logging_enabled: bool,
  *      wp_user_event_logging_enabled: bool,
+ *      wp_auth_logging_enabled: bool,
+ *      wp_auth_logging_config: AuthLoggingConfig,
  *      http_redactions: array<HttpHostRedactions>,
  *      http_whitelist: array<HttpHostWhitelist>,
  *  }
@@ -152,6 +163,83 @@ class Config implements RedactorConfig, WhitelistConfig {
         }
 
         return $this->http_logging_config['wp_user_event_logging_enabled'] ?? false;
+    }
+
+    /**
+     * Whether authentication event logging is enabled.
+     */
+    public function is_wp_auth_logging_enabled(): bool {
+        if ( ! $this->is_logging_enabled() ) {
+            return false;
+        }
+
+        return $this->http_logging_config['wp_auth_logging_enabled'] ?? false;
+    }
+
+    /**
+     * Whether login event logging is enabled.
+     */
+    public function is_auth_login_logging_enabled(): bool {
+        if ( ! $this->is_wp_auth_logging_enabled() ) {
+            return false;
+        }
+
+        return $this->http_logging_config['wp_auth_logging_config']['login'] ?? true;
+    }
+
+    /**
+     * Whether logout event logging is enabled.
+     */
+    public function is_auth_logout_logging_enabled(): bool {
+        if ( ! $this->is_wp_auth_logging_enabled() ) {
+            return false;
+        }
+
+        return $this->http_logging_config['wp_auth_logging_config']['logout'] ?? true;
+    }
+
+    /**
+     * Whether login failure event logging is enabled.
+     */
+    public function is_auth_login_failed_logging_enabled(): bool {
+        if ( ! $this->is_wp_auth_logging_enabled() ) {
+            return false;
+        }
+
+        return $this->http_logging_config['wp_auth_logging_config']['login_failed'] ?? false;
+    }
+
+    /**
+     * Whether password changed event logging is enabled.
+     */
+    public function is_auth_password_changed_logging_enabled(): bool {
+        if ( ! $this->is_wp_auth_logging_enabled() ) {
+            return false;
+        }
+
+        return $this->http_logging_config['wp_auth_logging_config']['password_changed'] ?? true;
+    }
+
+    /**
+     * Whether application password created event logging is enabled.
+     */
+    public function is_auth_app_password_created_logging_enabled(): bool {
+        if ( ! $this->is_wp_auth_logging_enabled() ) {
+            return false;
+        }
+
+        return $this->http_logging_config['wp_auth_logging_config']['app_password_created'] ?? true;
+    }
+
+    /**
+     * Whether application password deleted event logging is enabled.
+     */
+    public function is_auth_app_password_deleted_logging_enabled(): bool {
+        if ( ! $this->is_wp_auth_logging_enabled() ) {
+            return false;
+        }
+
+        return $this->http_logging_config['wp_auth_logging_config']['app_password_deleted'] ?? true;
     }
 
     /**
@@ -356,6 +444,15 @@ class Config implements RedactorConfig, WhitelistConfig {
                     'wp_rest_logging_enabled'        => true,
                     'wp_http_client_logging_enabled' => true,
                     'wp_user_event_logging_enabled'  => true,
+                    'wp_auth_logging_enabled'        => true,
+                    'wp_auth_logging_config'         => [
+                        'login'                => true,
+                        'logout'               => true,
+                        'login_failed'         => false,
+                        'password_changed'     => true,
+                        'app_password_created' => true,
+                        'app_password_deleted' => true,
+                    ],
                     'http_redactions_enabled'        => true,
                     'http_whitelist_enabled'         => false,
                     'http_redactions'                => [],

--- a/src/Lolly/Listeners/LogOnApplicationPasswordCreated.php
+++ b/src/Lolly/Listeners/LogOnApplicationPasswordCreated.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lolly\Listeners;
+
+use Lolly\Psr\Log\LoggerInterface;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * LogOnApplicationPasswordCreated class.
+ *
+ * Log when an application password is created for a user.
+ *
+ * @package Lolly
+ */
+class LogOnApplicationPasswordCreated {
+
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    /**
+     * Handle the wp_create_application_password action.
+     *
+     * @param int                  $user_id       User ID.
+     * @param array<string, mixed> $item          Application password item.
+     * @param string               $_new_password The unhashed generated application password (not logged).
+     */
+    public function handle( int $user_id, array $item, string $_new_password ): void {
+        $this->logger->info(
+            'Application password created.',
+            [
+                'target_user' => [ 'id' => $user_id ],
+                'app_name'    => $item['name'] ?? null,
+                'app_uuid'    => $item['uuid'] ?? null,
+            ]
+        );
+    }
+}

--- a/src/Lolly/Listeners/LogOnApplicationPasswordDeleted.php
+++ b/src/Lolly/Listeners/LogOnApplicationPasswordDeleted.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lolly\Listeners;
+
+use Lolly\Psr\Log\LoggerInterface;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * LogOnApplicationPasswordDeleted class.
+ *
+ * Log when an application password is deleted for a user.
+ *
+ * @package Lolly
+ */
+class LogOnApplicationPasswordDeleted {
+
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    /**
+     * Handle the wp_delete_application_password action.
+     *
+     * @param int                  $user_id User ID.
+     * @param array<string, mixed> $item    The application password item that was deleted.
+     */
+    public function handle( int $user_id, array $item ): void {
+        $this->logger->info(
+            'Application password deleted.',
+            [
+                'target_user' => [ 'id' => $user_id ],
+                'app_name'    => $item['name'] ?? null,
+                'app_uuid'    => $item['uuid'] ?? null,
+            ]
+        );
+    }
+}

--- a/src/Lolly/Listeners/LogOnLoginFailed.php
+++ b/src/Lolly/Listeners/LogOnLoginFailed.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lolly\Listeners;
+
+use Lolly\Psr\Log\LoggerInterface;
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * LogOnLoginFailed class.
+ *
+ * Log when a login attempt fails in WordPress.
+ *
+ * @package Lolly
+ */
+class LogOnLoginFailed {
+
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    /**
+     * Handle the wp_login_failed action.
+     *
+     * @param string   $username Username used in the failed login attempt.
+     * @param WP_Error $error    WP_Error object with the authentication failure details.
+     */
+    public function handle( string $username, WP_Error $error ): void {
+        $this->logger->warning(
+            'Login failed.',
+            [
+                'username' => $username,
+                'wp_error' => $error,
+            ]
+        );
+    }
+}

--- a/src/Lolly/Listeners/LogOnPasswordChanged.php
+++ b/src/Lolly/Listeners/LogOnPasswordChanged.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lolly\Listeners;
+
+use Lolly\Psr\Log\LoggerInterface;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * LogOnPasswordChanged class.
+ *
+ * Log when a user's password is changed in WordPress.
+ *
+ * @package Lolly
+ */
+class LogOnPasswordChanged {
+
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    /**
+     * Handle the after_password_reset action.
+     *
+     * Fires after the user's password is reset.
+     *
+     * @param \WP_User $user The user whose password was reset.
+     */
+    public function handle_password_reset( \WP_User $user ): void {
+        $this->logger->info(
+            'User password reset.',
+            [
+                'target_user' => [ 'id' => $user->ID ],
+            ]
+        );
+    }
+
+    /**
+     * Handle the profile_update action for password changes.
+     *
+     * @param int                  $user_id       User ID.
+     * @param \WP_User             $old_user_data Object containing user's data prior to update.
+     * @param array<string, mixed> $userdata      The raw array of data passed to wp_insert_user().
+     */
+    public function handle_profile_update( int $user_id, \WP_User $old_user_data, array $userdata ): void {
+        // Only log if password was changed.
+        if ( ! isset( $userdata['user_pass'] ) || $userdata['user_pass'] === '' ) {
+            return;
+        }
+
+        $this->logger->info(
+            'User password changed.',
+            [
+                'target_user' => [ 'id' => $user_id ],
+            ]
+        );
+    }
+}

--- a/src/Lolly/Listeners/LogOnUserLogin.php
+++ b/src/Lolly/Listeners/LogOnUserLogin.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lolly\Listeners;
+
+use Lolly\Psr\Log\LoggerInterface;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * LogOnUserLogin class.
+ *
+ * Log when a user logs into WordPress.
+ *
+ * @package Lolly
+ */
+class LogOnUserLogin {
+
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    /**
+     * Handle the wp_login action.
+     *
+     * @param string   $_user_login Username of the user logging in.
+     * @param \WP_User $user        WP_User object of the logged in user.
+     */
+    public function handle( string $_user_login, \WP_User $user ): void {
+        $this->logger->info(
+            'User logged in.',
+            [
+                'target_user' => [ 'id' => $user->ID ],
+            ]
+        );
+    }
+}

--- a/src/Lolly/Listeners/LogOnUserLogout.php
+++ b/src/Lolly/Listeners/LogOnUserLogout.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lolly\Listeners;
+
+use Lolly\Psr\Log\LoggerInterface;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * LogOnUserLogout class.
+ *
+ * Log when a user logs out of WordPress.
+ *
+ * @package Lolly
+ */
+class LogOnUserLogout {
+
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    /**
+     * Handle the wp_logout action.
+     *
+     * @param int $user_id ID of the user logging out.
+     */
+    public function handle( int $user_id ): void {
+        $this->logger->info(
+            'User logged out.',
+            [
+                'target_user' => [ 'id' => $user_id ],
+            ]
+        );
+    }
+}

--- a/src/Lolly/Listeners/Provider.php
+++ b/src/Lolly/Listeners/Provider.php
@@ -32,6 +32,12 @@ class Provider extends ServiceProvider {
         LogOnUserRoleAdded::class,
         LogOnUserRoleChanged::class,
         LogOnUserRoleRemoved::class,
+        LogOnUserLogin::class,
+        LogOnUserLogout::class,
+        LogOnLoginFailed::class,
+        LogOnPasswordChanged::class,
+        LogOnApplicationPasswordCreated::class,
+        LogOnApplicationPasswordDeleted::class,
     ];
 
     public function register() {
@@ -51,6 +57,31 @@ class Provider extends ServiceProvider {
             add_action( 'remove_user_role', $this->container->callback( LogOnUserRoleRemoved::class, 'handle' ), 10, 2 );
         }
 
+        if ( $this->config->is_auth_login_logging_enabled() ) {
+            add_action( 'wp_login', $this->container->callback( LogOnUserLogin::class, 'handle' ), 10, 2 );
+        }
+
+        if ( $this->config->is_auth_logout_logging_enabled() ) {
+            add_action( 'wp_logout', $this->container->callback( LogOnUserLogout::class, 'handle' ), 10, 1 );
+        }
+
+        if ( $this->config->is_auth_login_failed_logging_enabled() ) {
+            add_action( 'wp_login_failed', $this->container->callback( LogOnLoginFailed::class, 'handle' ), 10, 2 );
+        }
+
+        if ( $this->config->is_auth_password_changed_logging_enabled() ) {
+            add_action( 'after_password_reset', $this->container->callback( LogOnPasswordChanged::class, 'handle_password_reset' ), 10, 1 );
+            add_action( 'profile_update', $this->container->callback( LogOnPasswordChanged::class, 'handle_profile_update' ), 10, 3 );
+        }
+
+        if ( $this->config->is_auth_app_password_created_logging_enabled() ) {
+            add_action( 'wp_create_application_password', $this->container->callback( LogOnApplicationPasswordCreated::class, 'handle' ), 10, 3 );
+        }
+
+        if ( $this->config->is_auth_app_password_deleted_logging_enabled() ) {
+            add_action( 'wp_delete_application_password', $this->container->callback( LogOnApplicationPasswordDeleted::class, 'handle' ), 10, 2 );
+        }
+
         $this->container->bind( LogOnHttpClientRequest::class, LogOnHttpClientRequest::class );
         $this->container->bind( LogOnRestApiRequest::class, LogOnRestApiRequest::class );
         $this->container->bind( LogOnUserCreated::class, LogOnUserCreated::class );
@@ -58,5 +89,11 @@ class Provider extends ServiceProvider {
         $this->container->bind( LogOnUserRoleAdded::class, LogOnUserRoleAdded::class );
         $this->container->bind( LogOnUserRoleChanged::class, LogOnUserRoleChanged::class );
         $this->container->bind( LogOnUserRoleRemoved::class, LogOnUserRoleRemoved::class );
+        $this->container->bind( LogOnUserLogin::class, LogOnUserLogin::class );
+        $this->container->bind( LogOnUserLogout::class, LogOnUserLogout::class );
+        $this->container->bind( LogOnLoginFailed::class, LogOnLoginFailed::class );
+        $this->container->bind( LogOnPasswordChanged::class, LogOnPasswordChanged::class );
+        $this->container->bind( LogOnApplicationPasswordCreated::class, LogOnApplicationPasswordCreated::class );
+        $this->container->bind( LogOnApplicationPasswordDeleted::class, LogOnApplicationPasswordDeleted::class );
     }
 }

--- a/tests/Wpunit/Listeners/LogOnApplicationPasswordCreatedTest.php
+++ b/tests/Wpunit/Listeners/LogOnApplicationPasswordCreatedTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wpunit\Listeners;
+
+use Lolly\Listeners\LogOnApplicationPasswordCreated;
+use lucatume\WPBrowser\TestCase\WPTestCase;
+use Tests\Support\WpunitTester;
+
+/**
+ * @property WpunitTester $tester
+ */
+class LogOnApplicationPasswordCreatedTest extends WPTestCase {
+    public function _before(): void {
+        parent::_before();
+
+        $this->tester->updateSettings(
+            [
+                'enabled'                 => true,
+                'wp_auth_logging_enabled' => true,
+                'wp_auth_logging_config'  => [
+                    'login'                => true,
+                    'logout'               => true,
+                    'login_failed'         => false,
+                    'password_changed'     => true,
+                    'app_password_created' => true,
+                    'app_password_deleted' => true,
+                ],
+            ]
+        );
+
+        add_action(
+            'wp_create_application_password',
+            lolly()->callback( LogOnApplicationPasswordCreated::class, 'handle' ),
+            10,
+            3
+        );
+    }
+
+    public function _after(): void {
+        remove_all_actions( 'wp_create_application_password' );
+
+        parent::_after();
+    }
+
+    public function testLogsApplicationPasswordCreated(): void {
+        $user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+        $item    = [
+            'uuid' => wp_generate_uuid4(),
+            'name' => 'Test App',
+        ];
+
+        $this->tester->fakeLogger();
+
+        do_action( 'wp_create_application_password', $user_id, $item, 'unhashed_password' );
+
+        $this->tester->seeLogMessage( 'Application password created.', 'info' );
+    }
+
+    public function testCapturesTargetUserIdAndAppInfo(): void {
+        $user_id = self::factory()->user->create( [ 'role' => 'editor' ] );
+        $item    = [
+            'uuid' => wp_generate_uuid4(),
+            'name' => 'My Test Application',
+        ];
+
+        $this->tester->fakeLogger();
+
+        do_action( 'wp_create_application_password', $user_id, $item, 'unhashed_password' );
+
+        $records = $this->tester->grabLogRecords();
+        $this->assertCount( 1, $records );
+
+        $context = $records[0]->context;
+        $this->assertArrayHasKey( 'target_user', $context );
+        $this->assertIsArray( $context['target_user'] );
+        $this->assertEquals( $user_id, $context['target_user']['id'] );
+        $this->assertArrayHasKey( 'app_name', $context );
+        $this->assertArrayHasKey( 'app_uuid', $context );
+        $this->assertEquals( 'My Test Application', $context['app_name'] );
+    }
+
+    public function testDoesNotLogUnhashedPassword(): void {
+        $user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+        $item    = [
+            'uuid' => wp_generate_uuid4(),
+            'name' => 'Test App',
+        ];
+
+        $this->tester->fakeLogger();
+
+        do_action( 'wp_create_application_password', $user_id, $item, 'secret_password_value' );
+
+        $records = $this->tester->grabLogRecords();
+        $this->assertCount( 1, $records );
+
+        $context = $records[0]->context;
+        $this->assertArrayNotHasKey( 'password', $context );
+        $this->assertArrayNotHasKey( 'new_password', $context );
+
+        // Ensure the password isn't sneaking in anywhere.
+        $serialized = serialize( $context );
+        $this->assertStringNotContainsString( 'secret_password_value', $serialized );
+    }
+
+    public function testCapturesActorInExtra(): void {
+        $admin   = $this->tester->loginAsAdmin();
+        $user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+        $item    = [
+            'uuid' => wp_generate_uuid4(),
+            'name' => 'Test App',
+        ];
+
+        $this->tester->fakeLogger();
+
+        do_action( 'wp_create_application_password', $user_id, $item, 'unhashed_password' );
+
+        $records = $this->tester->grabLogRecords();
+        $this->assertCount( 1, $records );
+
+        $extra = $records[0]->extra;
+        $this->assertArrayHasKey( 'user', $extra );
+        $this->assertEquals( $admin->ID, $extra['user']['id'] );
+    }
+}

--- a/tests/Wpunit/Listeners/LogOnApplicationPasswordDeletedTest.php
+++ b/tests/Wpunit/Listeners/LogOnApplicationPasswordDeletedTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wpunit\Listeners;
+
+use Lolly\Listeners\LogOnApplicationPasswordDeleted;
+use lucatume\WPBrowser\TestCase\WPTestCase;
+use Tests\Support\WpunitTester;
+
+/**
+ * @property WpunitTester $tester
+ */
+class LogOnApplicationPasswordDeletedTest extends WPTestCase {
+    public function _before(): void {
+        parent::_before();
+
+        $this->tester->updateSettings(
+            [
+                'enabled'                 => true,
+                'wp_auth_logging_enabled' => true,
+                'wp_auth_logging_config'  => [
+                    'login'                => true,
+                    'logout'               => true,
+                    'login_failed'         => false,
+                    'password_changed'     => true,
+                    'app_password_created' => true,
+                    'app_password_deleted' => true,
+                ],
+            ]
+        );
+
+        add_action(
+            'wp_delete_application_password',
+            lolly()->callback( LogOnApplicationPasswordDeleted::class, 'handle' ),
+            10,
+            2
+        );
+    }
+
+    public function _after(): void {
+        remove_all_actions( 'wp_delete_application_password' );
+
+        parent::_after();
+    }
+
+    public function testLogsApplicationPasswordDeleted(): void {
+        $user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+        $item    = [
+            'uuid' => wp_generate_uuid4(),
+            'name' => 'Test App',
+        ];
+
+        $this->tester->fakeLogger();
+
+        do_action( 'wp_delete_application_password', $user_id, $item );
+
+        $this->tester->seeLogMessage( 'Application password deleted.', 'info' );
+    }
+
+    public function testCapturesTargetUserIdAndAppInfo(): void {
+        $user_id = self::factory()->user->create( [ 'role' => 'editor' ] );
+        $item    = [
+            'uuid' => wp_generate_uuid4(),
+            'name' => 'Deleted Application',
+        ];
+
+        $this->tester->fakeLogger();
+
+        do_action( 'wp_delete_application_password', $user_id, $item );
+
+        $records = $this->tester->grabLogRecords();
+        $this->assertCount( 1, $records );
+
+        $context = $records[0]->context;
+        $this->assertArrayHasKey( 'target_user', $context );
+        $this->assertIsArray( $context['target_user'] );
+        $this->assertEquals( $user_id, $context['target_user']['id'] );
+        $this->assertArrayHasKey( 'app_name', $context );
+        $this->assertArrayHasKey( 'app_uuid', $context );
+        $this->assertEquals( 'Deleted Application', $context['app_name'] );
+    }
+
+    public function testCapturesActorInExtra(): void {
+        $admin   = $this->tester->loginAsAdmin();
+        $user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+        $item    = [
+            'uuid' => wp_generate_uuid4(),
+            'name' => 'Test App',
+        ];
+
+        $this->tester->fakeLogger();
+
+        do_action( 'wp_delete_application_password', $user_id, $item );
+
+        $records = $this->tester->grabLogRecords();
+        $this->assertCount( 1, $records );
+
+        $extra = $records[0]->extra;
+        $this->assertArrayHasKey( 'user', $extra );
+        $this->assertEquals( $admin->ID, $extra['user']['id'] );
+    }
+}

--- a/tests/Wpunit/Listeners/LogOnLoginFailedTest.php
+++ b/tests/Wpunit/Listeners/LogOnLoginFailedTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wpunit\Listeners;
+
+use Lolly\Listeners\LogOnLoginFailed;
+use lucatume\WPBrowser\TestCase\WPTestCase;
+use Tests\Support\WpunitTester;
+use WP_Error;
+
+/**
+ * @property WpunitTester $tester
+ */
+class LogOnLoginFailedTest extends WPTestCase {
+    public function _before(): void {
+        parent::_before();
+
+        $this->tester->updateSettings(
+            [
+                'enabled'                 => true,
+                'wp_auth_logging_enabled' => true,
+                'wp_auth_logging_config'  => [
+                    'login'                => true,
+                    'logout'               => true,
+                    'login_failed'         => true,
+                    'password_changed'     => true,
+                    'app_password_created' => true,
+                    'app_password_deleted' => true,
+                ],
+            ]
+        );
+
+        add_action(
+            'wp_login_failed',
+            lolly()->callback( LogOnLoginFailed::class, 'handle' ),
+            10,
+            2
+        );
+    }
+
+    public function _after(): void {
+        remove_all_actions( 'wp_login_failed' );
+
+        parent::_after();
+    }
+
+    public function testLogsLoginFailed(): void {
+        $error = new WP_Error( 'incorrect_password', 'The password you entered is incorrect.' );
+
+        $this->tester->fakeLogger();
+
+        do_action( 'wp_login_failed', 'testuser', $error );
+
+        $this->tester->seeLogMessage( 'Login failed.', 'warning' );
+    }
+
+    public function testCapturesUsernameAndError(): void {
+        $error = new WP_Error( 'incorrect_password', 'The password you entered is incorrect.' );
+
+        $this->tester->fakeLogger();
+
+        do_action( 'wp_login_failed', 'attackeduser', $error );
+
+        $records = $this->tester->grabLogRecords();
+        $this->assertCount( 1, $records );
+
+        $context = $records[0]->context;
+        $this->assertArrayHasKey( 'username', $context );
+        $this->assertArrayHasKey( 'wp_error', $context );
+        $this->assertEquals( 'attackeduser', $context['username'] );
+    }
+}

--- a/tests/Wpunit/Listeners/LogOnPasswordChangedTest.php
+++ b/tests/Wpunit/Listeners/LogOnPasswordChangedTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wpunit\Listeners;
+
+use Lolly\Listeners\LogOnPasswordChanged;
+use lucatume\WPBrowser\TestCase\WPTestCase;
+use Tests\Support\WpunitTester;
+
+/**
+ * @property WpunitTester $tester
+ */
+class LogOnPasswordChangedTest extends WPTestCase {
+    public function _before(): void {
+        parent::_before();
+
+        $this->tester->updateSettings(
+            [
+                'enabled'                 => true,
+                'wp_auth_logging_enabled' => true,
+                'wp_auth_logging_config'  => [
+                    'login'                => true,
+                    'logout'               => true,
+                    'login_failed'         => false,
+                    'password_changed'     => true,
+                    'app_password_created' => true,
+                    'app_password_deleted' => true,
+                ],
+            ]
+        );
+
+        add_action(
+            'after_password_reset',
+            lolly()->callback( LogOnPasswordChanged::class, 'handle_password_reset' ),
+            10,
+            1
+        );
+
+        add_action(
+            'profile_update',
+            lolly()->callback( LogOnPasswordChanged::class, 'handle_profile_update' ),
+            10,
+            3
+        );
+    }
+
+    public function _after(): void {
+        remove_all_actions( 'after_password_reset' );
+        remove_all_actions( 'profile_update' );
+
+        parent::_after();
+    }
+
+    public function testLogsPasswordReset(): void {
+        $user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+        $user    = get_userdata( $user_id );
+
+        $this->tester->fakeLogger();
+
+        do_action( 'after_password_reset', $user );
+
+        $this->tester->seeLogMessage( 'User password reset.', 'info' );
+    }
+
+    public function testLogsPasswordChange(): void {
+        $user_id      = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+        $user         = get_userdata( $user_id );
+        $old_userdata = clone $user;
+
+        $this->tester->fakeLogger();
+
+        do_action(
+            'profile_update',
+            $user_id,
+            $old_userdata,
+            [ 'user_pass' => 'newpassword123' ]
+        );
+
+        $this->tester->seeLogMessage( 'User password changed.', 'info' );
+    }
+
+    public function testDoesNotLogProfileUpdateWithoutPasswordChange(): void {
+        $user_id      = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+        $user         = get_userdata( $user_id );
+        $old_userdata = clone $user;
+
+        $this->tester->fakeLogger();
+
+        do_action(
+            'profile_update',
+            $user_id,
+            $old_userdata,
+            [ 'display_name' => 'New Display Name' ]
+        );
+
+        $records = $this->tester->grabLogRecords();
+        $this->assertCount( 0, $records );
+    }
+
+    public function testCapturesTargetUserId(): void {
+        $user_id = self::factory()->user->create( [ 'role' => 'editor' ] );
+        $user    = get_userdata( $user_id );
+
+        $this->tester->fakeLogger();
+
+        do_action( 'after_password_reset', $user );
+
+        $records = $this->tester->grabLogRecords();
+        $this->assertCount( 1, $records );
+
+        $context = $records[0]->context;
+        $this->assertArrayHasKey( 'target_user', $context );
+        $this->assertIsArray( $context['target_user'] );
+        $this->assertEquals( $user_id, $context['target_user']['id'] );
+    }
+
+    public function testCapturesActorInExtra(): void {
+        $admin   = $this->tester->loginAsAdmin();
+        $user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+        $user    = get_userdata( $user_id );
+
+        $this->tester->fakeLogger();
+
+        do_action( 'after_password_reset', $user );
+
+        $records = $this->tester->grabLogRecords();
+        $this->assertCount( 1, $records );
+
+        $extra = $records[0]->extra;
+        $this->assertArrayHasKey( 'user', $extra );
+        $this->assertEquals( $admin->ID, $extra['user']['id'] );
+    }
+}

--- a/tests/Wpunit/Listeners/LogOnUserLoginTest.php
+++ b/tests/Wpunit/Listeners/LogOnUserLoginTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wpunit\Listeners;
+
+use Lolly\Listeners\LogOnUserLogin;
+use lucatume\WPBrowser\TestCase\WPTestCase;
+use Tests\Support\WpunitTester;
+
+/**
+ * @property WpunitTester $tester
+ */
+class LogOnUserLoginTest extends WPTestCase {
+    public function _before(): void {
+        parent::_before();
+
+        $this->tester->updateSettings(
+            [
+                'enabled'                 => true,
+                'wp_auth_logging_enabled' => true,
+                'wp_auth_logging_config'  => [
+                    'login'                => true,
+                    'logout'               => true,
+                    'login_failed'         => false,
+                    'password_changed'     => true,
+                    'app_password_created' => true,
+                    'app_password_deleted' => true,
+                ],
+            ]
+        );
+
+        add_action(
+            'wp_login',
+            lolly()->callback( LogOnUserLogin::class, 'handle' ),
+            10,
+            2
+        );
+    }
+
+    public function _after(): void {
+        remove_all_actions( 'wp_login' );
+
+        parent::_after();
+    }
+
+    public function testLogsUserLogin(): void {
+        $user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+        $user    = get_userdata( $user_id );
+
+        $this->tester->fakeLogger();
+
+        do_action( 'wp_login', $user->user_login, $user );
+
+        $this->tester->seeLogMessage( 'User logged in.', 'info' );
+    }
+
+    public function testCapturesTargetUserId(): void {
+        $user_id = self::factory()->user->create( [ 'role' => 'editor' ] );
+        $user    = get_userdata( $user_id );
+
+        $this->tester->fakeLogger();
+
+        do_action( 'wp_login', $user->user_login, $user );
+
+        $records = $this->tester->grabLogRecords();
+        $this->assertCount( 1, $records );
+
+        $context = $records[0]->context;
+        $this->assertArrayHasKey( 'target_user', $context );
+        $this->assertIsArray( $context['target_user'] );
+        $this->assertEquals( $user_id, $context['target_user']['id'] );
+    }
+
+    public function testCapturesActorInExtra(): void {
+        $user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+        $user    = get_userdata( $user_id );
+
+        // Simulate the logged in user.
+        wp_set_current_user( $user_id );
+
+        $this->tester->fakeLogger();
+
+        do_action( 'wp_login', $user->user_login, $user );
+
+        $records = $this->tester->grabLogRecords();
+        $this->assertCount( 1, $records );
+
+        $extra = $records[0]->extra;
+        $this->assertArrayHasKey( 'user', $extra );
+        $this->assertEquals( $user_id, $extra['user']['id'] );
+    }
+}

--- a/tests/Wpunit/Listeners/LogOnUserLogoutTest.php
+++ b/tests/Wpunit/Listeners/LogOnUserLogoutTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wpunit\Listeners;
+
+use Lolly\Listeners\LogOnUserLogout;
+use lucatume\WPBrowser\TestCase\WPTestCase;
+use Tests\Support\WpunitTester;
+
+/**
+ * @property WpunitTester $tester
+ */
+class LogOnUserLogoutTest extends WPTestCase {
+    public function _before(): void {
+        parent::_before();
+
+        $this->tester->updateSettings(
+            [
+                'enabled'                 => true,
+                'wp_auth_logging_enabled' => true,
+                'wp_auth_logging_config'  => [
+                    'login'                => true,
+                    'logout'               => true,
+                    'login_failed'         => false,
+                    'password_changed'     => true,
+                    'app_password_created' => true,
+                    'app_password_deleted' => true,
+                ],
+            ]
+        );
+
+        add_action(
+            'wp_logout',
+            lolly()->callback( LogOnUserLogout::class, 'handle' ),
+            10,
+            1
+        );
+    }
+
+    public function _after(): void {
+        remove_all_actions( 'wp_logout' );
+
+        parent::_after();
+    }
+
+    public function testLogsUserLogout(): void {
+        $user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+
+        $this->tester->fakeLogger();
+
+        do_action( 'wp_logout', $user_id );
+
+        $this->tester->seeLogMessage( 'User logged out.', 'info' );
+    }
+
+    public function testCapturesTargetUserId(): void {
+        $user_id = self::factory()->user->create( [ 'role' => 'editor' ] );
+
+        $this->tester->fakeLogger();
+
+        do_action( 'wp_logout', $user_id );
+
+        $records = $this->tester->grabLogRecords();
+        $this->assertCount( 1, $records );
+
+        $context = $records[0]->context;
+        $this->assertArrayHasKey( 'target_user', $context );
+        $this->assertIsArray( $context['target_user'] );
+        $this->assertEquals( $user_id, $context['target_user']['id'] );
+    }
+
+    public function testCapturesActorInExtra(): void {
+        $user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+
+        // Simulate the logged in user who is logging out.
+        wp_set_current_user( $user_id );
+
+        $this->tester->fakeLogger();
+
+        do_action( 'wp_logout', $user_id );
+
+        $records = $this->tester->grabLogRecords();
+        $this->assertCount( 1, $records );
+
+        $extra = $records[0]->extra;
+        $this->assertArrayHasKey( 'user', $extra );
+        $this->assertEquals( $user_id, $extra['user']['id'] );
+    }
+}

--- a/tests/Wpunit/Rest/SettingsTest.php
+++ b/tests/Wpunit/Rest/SettingsTest.php
@@ -96,6 +96,15 @@ class SettingsTest extends WPRestApiTestCase {
                 'wp_rest_logging_enabled'        => false,
                 'wp_http_client_logging_enabled' => false,
                 'wp_user_event_logging_enabled'  => false,
+                'wp_auth_logging_enabled'        => true,
+                'wp_auth_logging_config'         => [
+                    'login'                => true,
+                    'logout'               => false,
+                    'login_failed'         => true,
+                    'password_changed'     => true,
+                    'app_password_created' => false,
+                    'app_password_deleted' => true,
+                ],
                 'http_redactions_enabled'        => false,
                 'http_whitelist_enabled'         => true,
                 'http_redactions'                => [
@@ -148,6 +157,14 @@ class SettingsTest extends WPRestApiTestCase {
         $this->assertEquals( 'example.com', $lolly_settings['http_redactions'][0]['host'] );
         $this->assertCount( 1, $lolly_settings['http_whitelist'] );
         $this->assertEquals( 'api.example.org', $lolly_settings['http_whitelist'][0]['host'] );
+
+        $this->assertTrue( $lolly_settings['wp_auth_logging_enabled'] );
+        $this->assertIsArray( $lolly_settings['wp_auth_logging_config'] );
+        $this->assertTrue( $lolly_settings['wp_auth_logging_config']['login'] );
+        $this->assertFalse( $lolly_settings['wp_auth_logging_config']['logout'] );
+        $this->assertTrue( $lolly_settings['wp_auth_logging_config']['login_failed'] );
+        $this->assertFalse( $lolly_settings['wp_auth_logging_config']['app_password_created'] );
+        $this->assertTrue( $lolly_settings['wp_auth_logging_config']['app_password_deleted'] );
     }
 
     public function testSchemaIsProperlyDefined(): void {


### PR DESCRIPTION
Lolly can now log authentication events including login, logout, password
changes, and application password management. A new settings card allows
granular control over which auth events to capture.

Failed login attempts are disabled by default due to potential high volume on
sites under attack. Each event logs the target user ID in ECS-compatible
format, with the actor captured automatically by the existing user processor.