### PR TITLE
feat: add fatal error logging with optional drop-in handler

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Lolly Log is an ECS (Elastic Common Schema) compatible HTTP request/response log
 ```
 src/Lolly/
 ├── Admin/           # Settings page UI
-├── Config/          # Configuration loading, validation, settings registration
+├── Config/          # Configuration loading and validation
 ├── Lib/
 │   ├── Contracts/   # Interfaces for redactors and whitelist
 │   ├── Enums/       # HttpRedactionType enum
@@ -20,13 +20,16 @@ src/Lolly/
 │   └── ValueObjects/# Data structures (RedactionItem, etc.)
 ├── Listeners/       # HTTP event listeners (REST API, HTTP Client)
 ├── Log/             # Logger factory (Monolog)
+├── Rest/            # Custom REST API controllers
+├── Schema/          # JSON Schema loading and caching
 └── Processors/      # WordPress-specific processors
 ```
 
 Key patterns:
 - **Listeners** capture HTTP events and delegate to processors
 - **Processors** transform log records (ECS format, redaction)
-- **Config** manages settings via WordPress options with JSON Schema validation
+- **Config** manages settings via WordPress options
+- **Rest** provides custom `/lolly/v1/settings` endpoint with JSON Schema validation
 
 ## Local Development
 
@@ -85,7 +88,7 @@ slic composer install            # Install dependencies
 slic composer strauss            # Build prefixed dependencies
 slic airplane-mode on            # Block external HTTP requests
 slic run Wpunit                  # Run tests
-slic run Wpunit:SettingsTest     # Run specific test
+slic run Wpunit:SettingsControllerTest  # Run specific test
 
 # Drop into slic shell for debugging
 slic shell

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
     "autoload-dev": {
         "psr-4": {
             "Tests\\Support\\": "tests/Support",
+            "Tests\\Stubs\\": "tests/Stubs",
             "Tests\\Wpunit\\": "tests/Wpunit"
         }
     },

--- a/resources/js/components/dropin-card.tsx
+++ b/resources/js/components/dropin-card.tsx
@@ -1,0 +1,154 @@
+import React from 'react';
+
+import {
+    Button,
+    Card,
+    CardBody,
+    CardHeader,
+    Notice,
+    Spinner,
+    __experimentalVStack as VStack,
+    __experimentalText as Text,
+} from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { __, sprintf } from '@wordpress/i18n';
+
+import { store as settingsStore } from '../settings/store';
+
+export default function DropinCard(): React.ReactNode {
+    const { status, isBusy, isInstalling, isUninstalling, error } = useSelect(
+        (select) => ({
+            status: select(settingsStore).getDropinStatus(),
+            isBusy: select(settingsStore).isDropinBusy(),
+            isInstalling: select(settingsStore).isDropinInstalling(),
+            isUninstalling: select(settingsStore).isDropinUninstalling(),
+            error: select(settingsStore).getDropinError(),
+        }),
+        []
+    );
+
+    const { installDropin, uninstallDropin, clearDropinError } =
+        useDispatch(settingsStore);
+
+    // Status is still loading
+    if (status === undefined) {
+        return (
+            <Card>
+                <CardHeader>
+                    <h2 style={{ margin: 0 }}>
+                        {__('Fatal Error Handler', 'lolly')}
+                    </h2>
+                </CardHeader>
+                <CardBody>
+                    <Spinner />
+                </CardBody>
+            </Card>
+        );
+    }
+
+    const isLollyInstalled = status.installed && status.is_lolly;
+    const isThirdParty = status.installed && !status.is_lolly;
+
+    return (
+        <Card>
+            <CardHeader>
+                <h2 style={{ margin: 0 }}>
+                    {__('Fatal Error Handler', 'lolly')}
+                </h2>
+            </CardHeader>
+            <CardBody>
+                <VStack spacing={4}>
+                    <Text>
+                        {__(
+                            'Install the fatal error handler drop-in for enhanced error logging with backtraces, extension detection, and recovery mode integration.',
+                            'lolly'
+                        )}
+                    </Text>
+
+                    {error && (
+                        <Notice
+                            status="error"
+                            isDismissible={true}
+                            onDismiss={clearDropinError}
+                        >
+                            {error.message}
+                        </Notice>
+                    )}
+
+                    {!status.writable && (
+                        <Notice status="warning" isDismissible={false}>
+                            {__(
+                                'The wp-content directory is not writable. Cannot install or uninstall the drop-in.',
+                                'lolly'
+                            )}
+                        </Notice>
+                    )}
+
+                    {isThirdParty && (
+                        <Notice status="warning" isDismissible={false}>
+                            {__(
+                                'A fatal error handler from another plugin is already installed. Uninstall it first to use the Lolly handler.',
+                                'lolly'
+                            )}
+                        </Notice>
+                    )}
+
+                    {isLollyInstalled && (
+                        <Notice status="success" isDismissible={false}>
+                            {status.version
+                                ? sprintf(
+                                      /* translators: %s: version number */
+                                      __(
+                                          'Lolly fatal error handler v%s is installed.',
+                                          'lolly'
+                                      ),
+                                      status.version
+                                  )
+                                : __(
+                                      'Lolly fatal error handler is installed.',
+                                      'lolly'
+                                  )}
+                        </Notice>
+                    )}
+
+                    {!status.installed && status.writable && (
+                        <Notice status="info" isDismissible={false}>
+                            {__(
+                                'The drop-in is not installed. Basic error logging via shutdown hook is active.',
+                                'lolly'
+                            )}
+                        </Notice>
+                    )}
+
+                    <div>
+                        {isLollyInstalled ? (
+                            <Button
+                                isDestructive
+                                isBusy={isUninstalling}
+                                disabled={isBusy || !status.writable}
+                                onClick={uninstallDropin}
+                            >
+                                {isUninstalling
+                                    ? __('Uninstalling\u2026', 'lolly')
+                                    : __('Uninstall Drop-in', 'lolly')}
+                            </Button>
+                        ) : (
+                            <Button
+                                variant="secondary"
+                                isBusy={isInstalling}
+                                disabled={
+                                    isBusy || !status.writable || isThirdParty
+                                }
+                                onClick={installDropin}
+                            >
+                                {isInstalling
+                                    ? __('Installing\u2026', 'lolly')
+                                    : __('Install Drop-in', 'lolly')}
+                            </Button>
+                        )}
+                    </div>
+                </VStack>
+            </CardBody>
+        </Card>
+    );
+}

--- a/resources/js/components/settings-page.tsx
+++ b/resources/js/components/settings-page.tsx
@@ -16,6 +16,8 @@ import { __ } from '@wordpress/i18n';
 import { store as settingStore } from '../settings/store';
 import type { AuthLoggingConfig, FeatureConfig } from '../types';
 
+import DropinCard from './dropin-card';
+
 const defaultAuthConfig: AuthLoggingConfig = {
     enabled: true,
     login: true,
@@ -287,6 +289,8 @@ export default function SettingsPage(): React.ReactNode {
                     </CardBody>
                 </Card>
             )}
+
+            <DropinCard />
 
             <HStack>
                 <Button

--- a/resources/js/settings/store/actions.ts
+++ b/resources/js/settings/store/actions.ts
@@ -4,7 +4,7 @@ import { __ } from '@wordpress/i18n';
 import { Settings, WpRestApiError } from '../../types';
 import { isWpRestApiError } from '../../utils';
 
-import { Action, SettingsThunk } from './types';
+import { Action, DropinStatus, SettingsThunk } from './types';
 
 /**
  * Edit a settings property.
@@ -74,6 +74,91 @@ export const saveEditedSettings =
 
             dispatch({
                 type: 'SAVE_SETTINGS_RECORD_FAILED',
+                error,
+            });
+        }
+    };
+
+/**
+ * Clear the drop-in error.
+ */
+export function clearDropinError(): Action {
+    return {
+        type: 'CLEAR_DROPIN_ERROR',
+    };
+}
+
+/**
+ * Install the drop-in.
+ */
+export const installDropin =
+    (): SettingsThunk =>
+    async ({ dispatch }) => {
+        dispatch({
+            type: 'INSTALL_DROPIN_START',
+        });
+
+        try {
+            const status = await apiFetch<DropinStatus>({
+                path: '/lolly/v1/settings/dropin',
+                method: 'POST',
+            });
+
+            dispatch({
+                type: 'INSTALL_DROPIN_FINISHED',
+                status,
+            });
+        } catch (e: unknown) {
+            const error: WpRestApiError = isWpRestApiError(e)
+                ? e
+                : {
+                      code: 'lolly.install-dropin-failed',
+                      message: __(
+                          'Failed to install the drop-in, an unknown error occurred.',
+                          'lolly'
+                      ),
+                  };
+
+            dispatch({
+                type: 'INSTALL_DROPIN_FAILED',
+                error,
+            });
+        }
+    };
+
+/**
+ * Uninstall the drop-in.
+ */
+export const uninstallDropin =
+    (): SettingsThunk =>
+    async ({ dispatch }) => {
+        dispatch({
+            type: 'UNINSTALL_DROPIN_START',
+        });
+
+        try {
+            const status = await apiFetch<DropinStatus>({
+                path: '/lolly/v1/settings/dropin',
+                method: 'DELETE',
+            });
+
+            dispatch({
+                type: 'UNINSTALL_DROPIN_FINISHED',
+                status,
+            });
+        } catch (e: unknown) {
+            const error: WpRestApiError = isWpRestApiError(e)
+                ? e
+                : {
+                      code: 'lolly.uninstall-dropin-failed',
+                      message: __(
+                          'Failed to uninstall the drop-in, an unknown error occurred.',
+                          'lolly'
+                      ),
+                  };
+
+            dispatch({
+                type: 'UNINSTALL_DROPIN_FAILED',
                 error,
             });
         }

--- a/resources/js/settings/store/reducer.ts
+++ b/resources/js/settings/store/reducer.ts
@@ -1,6 +1,12 @@
 import { combineReducers } from '@wordpress/data';
 
-import type { SettingsState, State, Action, EditsState } from './types';
+import type {
+    SettingsState,
+    State,
+    Action,
+    EditsState,
+    DropinState,
+} from './types';
 
 function settings(state: SettingsState, action: Action): SettingsState {
     switch (action.type) {
@@ -71,9 +77,86 @@ function edits(state: EditsState, action: Action): EditsState {
     return state;
 }
 
+function dropin(state: DropinState, action: Action): DropinState {
+    switch (action.type) {
+        case 'FETCH_DROPIN_STATUS_START': {
+            return {
+                ...state,
+                isLoading: true,
+                error: undefined,
+            };
+        }
+        case 'FETCH_DROPIN_STATUS_FINISHED': {
+            return {
+                ...state,
+                isLoading: false,
+                status: action.status,
+            };
+        }
+        case 'FETCH_DROPIN_STATUS_FAILED': {
+            return {
+                ...state,
+                isLoading: false,
+                error: action.error,
+            };
+        }
+        case 'INSTALL_DROPIN_START': {
+            return {
+                ...state,
+                isInstalling: true,
+                error: undefined,
+            };
+        }
+        case 'INSTALL_DROPIN_FINISHED': {
+            return {
+                ...state,
+                isInstalling: false,
+                status: action.status,
+            };
+        }
+        case 'INSTALL_DROPIN_FAILED': {
+            return {
+                ...state,
+                isInstalling: false,
+                error: action.error,
+            };
+        }
+        case 'UNINSTALL_DROPIN_START': {
+            return {
+                ...state,
+                isUninstalling: true,
+                error: undefined,
+            };
+        }
+        case 'UNINSTALL_DROPIN_FINISHED': {
+            return {
+                ...state,
+                isUninstalling: false,
+                status: action.status,
+            };
+        }
+        case 'UNINSTALL_DROPIN_FAILED': {
+            return {
+                ...state,
+                isUninstalling: false,
+                error: action.error,
+            };
+        }
+        case 'CLEAR_DROPIN_ERROR': {
+            return {
+                ...state,
+                error: undefined,
+            };
+        }
+    }
+
+    return state;
+}
+
 export default combineReducers({
     settings,
     edits,
+    dropin,
 });
 
 export function initializeDefaultState(): State {
@@ -86,6 +169,13 @@ export function initializeDefaultState(): State {
         edits: {
             edits: {},
             isSaving: false,
+            error: undefined,
+        },
+        dropin: {
+            status: undefined,
+            isLoading: false,
+            isInstalling: false,
+            isUninstalling: false,
             error: undefined,
         },
     };

--- a/resources/js/settings/store/resolvers.ts
+++ b/resources/js/settings/store/resolvers.ts
@@ -4,7 +4,7 @@ import { __ } from '@wordpress/i18n';
 import type { Settings, WpRestApiError } from '../../types';
 import { isWpRestApiError, forwardResolver } from '../../utils';
 
-import type { SettingsThunk } from './types';
+import type { DropinStatus, SettingsThunk } from './types';
 
 export const getSettings =
     (): SettingsThunk =>
@@ -37,3 +37,37 @@ export const getSettings =
     };
 
 export const getEditedSettings = forwardResolver('getSettings');
+
+export const getDropinStatus =
+    (): SettingsThunk =>
+    async ({ dispatch }) => {
+        dispatch({
+            type: 'FETCH_DROPIN_STATUS_START',
+        });
+
+        try {
+            const status = await apiFetch<DropinStatus>({
+                path: '/lolly/v1/settings/dropin',
+            });
+
+            dispatch({
+                type: 'FETCH_DROPIN_STATUS_FINISHED',
+                status,
+            });
+        } catch (e: unknown) {
+            const error: WpRestApiError = isWpRestApiError(e)
+                ? e
+                : {
+                      code: 'lolly.fetch-dropin-status-failed',
+                      message: __(
+                          'Failed to fetch drop-in status, an unknown error occurred.',
+                          'lolly'
+                      ),
+                  };
+
+            dispatch({
+                type: 'FETCH_DROPIN_STATUS_FAILED',
+                error,
+            });
+        }
+    };

--- a/resources/js/settings/store/selectors.ts
+++ b/resources/js/settings/store/selectors.ts
@@ -2,7 +2,7 @@ import { createSelector } from '@wordpress/data';
 
 import type { Settings, WpRestApiError } from '../../types';
 
-import { State } from './types';
+import { DropinStatus, State } from './types';
 
 export function getSettings(state: State): Settings | undefined {
     return state.settings.settings;
@@ -55,4 +55,34 @@ export function hasEdits(state: State, key: keyof Settings): boolean {
 
 export function getEditError(state: State): WpRestApiError | undefined {
     return state.edits.error;
+}
+
+// Drop-in selectors
+
+export function getDropinStatus(state: State): DropinStatus | undefined {
+    return state.dropin.status;
+}
+
+export function isDropinLoading(state: State): boolean {
+    return state.dropin.isLoading;
+}
+
+export function isDropinInstalling(state: State): boolean {
+    return state.dropin.isInstalling;
+}
+
+export function isDropinUninstalling(state: State): boolean {
+    return state.dropin.isUninstalling;
+}
+
+export function isDropinBusy(state: State): boolean {
+    return (
+        state.dropin.isLoading ||
+        state.dropin.isInstalling ||
+        state.dropin.isUninstalling
+    );
+}
+
+export function getDropinError(state: State): WpRestApiError | undefined {
+    return state.dropin.error;
 }

--- a/resources/js/settings/store/types.ts
+++ b/resources/js/settings/store/types.ts
@@ -9,6 +9,16 @@ import type { Settings, WpRestApiError } from '../../types';
 import * as actions from './actions';
 import * as selectors from './selectors';
 
+/**
+ * Drop-in status returned by the API.
+ */
+export interface DropinStatus {
+    installed: boolean;
+    is_lolly: boolean;
+    version: string | null;
+    writable: boolean;
+}
+
 export type Action =
     | { type: 'EDIT_SETTINGS_RECORD'; edits: Partial<Settings> }
     | { type: 'SAVE_SETTINGS_RECORD_START' }
@@ -16,11 +26,22 @@ export type Action =
     | { type: 'SAVE_SETTINGS_RECORD_FAILED'; error: WpRestApiError }
     | { type: 'FETCH_SETTINGS_START' }
     | { type: 'FETCH_SETTINGS_FINISHED'; settings: Settings }
-    | { type: 'FETCH_SETTINGS_FAILED'; error: WpRestApiError };
+    | { type: 'FETCH_SETTINGS_FAILED'; error: WpRestApiError }
+    | { type: 'FETCH_DROPIN_STATUS_START' }
+    | { type: 'FETCH_DROPIN_STATUS_FINISHED'; status: DropinStatus }
+    | { type: 'FETCH_DROPIN_STATUS_FAILED'; error: WpRestApiError }
+    | { type: 'INSTALL_DROPIN_START' }
+    | { type: 'INSTALL_DROPIN_FINISHED'; status: DropinStatus }
+    | { type: 'INSTALL_DROPIN_FAILED'; error: WpRestApiError }
+    | { type: 'UNINSTALL_DROPIN_START' }
+    | { type: 'UNINSTALL_DROPIN_FINISHED'; status: DropinStatus }
+    | { type: 'UNINSTALL_DROPIN_FAILED'; error: WpRestApiError }
+    | { type: 'CLEAR_DROPIN_ERROR' };
 
 export interface State {
     settings: SettingsState;
     edits: EditsState;
+    dropin: DropinState;
 }
 
 export interface SettingsState {
@@ -35,6 +56,14 @@ export interface EditsState {
     // value.
     edits: Partial<Settings>;
     isSaving: boolean;
+    error: WpRestApiError | undefined;
+}
+
+export interface DropinState {
+    status: DropinStatus | undefined;
+    isLoading: boolean;
+    isInstalling: boolean;
+    isUninstalling: boolean;
     error: WpRestApiError | undefined;
 }
 

--- a/resources/templates/fatal-error-handler.php
+++ b/resources/templates/fatal-error-handler.php
@@ -1,0 +1,332 @@
+<?php
+/**
+ * Plugin Name: Lolly Fatal Error Handler
+ * Description: Drop-in fatal error handler for Lolly Log plugin.
+ * Version: 1.0.0
+ *
+ * This file is a WordPress drop-in that provides enhanced fatal error logging.
+ * It captures detailed error information including backtraces and extension detection.
+ *
+ * @package Lolly
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Global flag to indicate the drop-in has already logged the fatal error.
+ * This prevents duplicate logging from the shutdown hook.
+ *
+ * @var bool
+ */
+$GLOBALS['lolly_fatal_error_logged'] = false;
+
+/**
+ * Lolly Fatal Error Handler.
+ *
+ * Extends the WordPress fatal error handler to provide enhanced logging
+ * capabilities with the Lolly Log plugin.
+ */
+class Lolly_Fatal_Error_Handler extends WP_Fatal_Error_Handler {
+
+    /**
+     * Runs the shutdown handler.
+     *
+     * This method is invoked when a fatal error occurs. It logs the error
+     * using Lolly if available, then falls back to WordPress default behavior.
+     */
+    public function handle(): void {
+        $error = $this->detect_error();
+
+        if ( $error === null ) {
+            return;
+        }
+
+        // Attempt to log with Lolly if available.
+        if ( $this->log_with_lolly( $error ) ) {
+            $GLOBALS['lolly_fatal_error_logged'] = true;
+        }
+
+        // Call parent handler for recovery mode and error display.
+        parent::handle();
+    }
+
+    /**
+     * Log the fatal error using Lolly.
+     *
+     * @param array{type: int, message: string, file: string, line: int} $error Error details from error_get_last().
+     *
+     * @return bool True if logged successfully, false otherwise.
+     */
+    private function log_with_lolly( array $error ): bool {
+        // Check if Lolly is available.
+        if ( ! function_exists( 'lolly' ) ) {
+            return false;
+        }
+
+        try {
+            $context = $this->build_error_context( $error );
+            lolly()->critical( $this->format_error_message( $error ), $context );
+            return true;
+        } catch ( Throwable $e ) {
+            // Silently fail if logging throws an exception.
+            return false;
+        }
+    }
+
+    /**
+     * Build the error context for logging.
+     *
+     * @param array{type: int, message: string, file: string, line: int} $error Error details.
+     *
+     * @return array<string, mixed> The error context.
+     */
+    private function build_error_context( array $error ): array {
+        $context = [
+            'error' => [
+                'type'    => $this->get_error_type_name( $error['type'] ),
+                'code'    => $error['type'],
+                'message' => $error['message'],
+                'file'    => $error['file'],
+                'line'    => $error['line'],
+            ],
+        ];
+
+        // Add backtrace if available (requires Xdebug - standard debug_backtrace doesn't work for fatal errors).
+        $backtrace = $this->get_backtrace();
+        if ( ! empty( $backtrace ) ) {
+            $context['error']['stack_trace'] = $backtrace;
+        }
+
+        // Add extension detection (may not work if fatal occurred before WP fully loaded).
+        $extension = $this->detect_extension( $error );
+        if ( $extension !== null ) {
+            $context['error']['extension'] = $extension;
+        }
+
+        // Add recovery mode status.
+        $context['error']['recovery_mode'] = $this->is_recovery_mode_active();
+
+        // Add WordPress context if available (functions may not exist during early boot fatal).
+        if ( function_exists( 'get_bloginfo' ) ) {
+            $context['wordpress'] = [
+                'version'   => get_bloginfo( 'version' ),
+                'multisite' => function_exists( 'is_multisite' ) && is_multisite(),
+            ];
+        }
+
+        // Add request context if available.
+        if ( isset( $_SERVER['REQUEST_URI'] ) ) {
+            $context['http'] = [
+                'request' => [
+                    'method' => isset( $_SERVER['REQUEST_METHOD'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) : 'unknown',
+                    // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- URI sanitization would corrupt valid URIs.
+                    'url'    => isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '',
+                ],
+            ];
+        }
+
+        return $context;
+    }
+
+    /**
+     * Format the error message for logging.
+     *
+     * @param array{type: int, message: string, file: string, line: int} $error Error details.
+     *
+     * @return string Formatted error message.
+     */
+    private function format_error_message( array $error ): string {
+        return sprintf(
+            'PHP Fatal Error: %s in %s on line %d',
+            $error['message'],
+            $error['file'],
+            $error['line']
+        );
+    }
+
+    /**
+     * Get the human-readable name for an error type.
+     *
+     * @param int $type The PHP error type constant.
+     *
+     * @return string The error type name.
+     */
+    private function get_error_type_name( int $type ): string {
+        $types = [
+            E_ERROR             => 'E_ERROR',
+            E_PARSE             => 'E_PARSE',
+            E_CORE_ERROR        => 'E_CORE_ERROR',
+            E_COMPILE_ERROR     => 'E_COMPILE_ERROR',
+            E_USER_ERROR        => 'E_USER_ERROR',
+            E_RECOVERABLE_ERROR => 'E_RECOVERABLE_ERROR',
+        ];
+
+        return $types[ $type ] ?? 'UNKNOWN';
+    }
+
+    /**
+     * Get the backtrace if available.
+     *
+     * @return array<int, array{file?: string, line?: int, function?: string, class?: string, type?: string}>
+     */
+    private function get_backtrace(): array {
+        // Check if Xdebug's extended info is available.
+        if ( function_exists( 'xdebug_get_function_stack' ) ) {
+            // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.xdebug_get_function_stackFound -- Optional Xdebug function.
+            $stack = xdebug_get_function_stack();
+            if ( is_array( $stack ) ) {
+                // Reverse to get most recent call first.
+                return array_reverse( $stack );
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * Detect the WordPress extension (plugin or theme) responsible for the error.
+     *
+     * Note: This may not work if the fatal error occurred before WordPress fully loaded.
+     *
+     * @param array{type: int, message: string, file: string, line: int} $error Error details.
+     *
+     * @return array{type: string, slug: string, name?: string}|null Extension info or null if not detected.
+     */
+    private function detect_extension( array $error ): ?array {
+        // These functions/constants may not exist during early boot.
+        if ( ! function_exists( 'wp_normalize_path' ) || ! defined( 'WP_PLUGIN_DIR' ) ) {
+            return null;
+        }
+
+        $file = wp_normalize_path( $error['file'] );
+
+        // Check if error is in a plugin.
+        $plugins_dir = wp_normalize_path( WP_PLUGIN_DIR );
+        if ( str_starts_with( $file, $plugins_dir . '/' ) ) {
+            $relative = substr( $file, strlen( $plugins_dir ) + 1 );
+            $parts    = explode( '/', $relative );
+            $slug     = $parts[0] ?? '';
+
+            if ( ! empty( $slug ) ) {
+                return [
+                    'type' => 'plugin',
+                    'slug' => $slug,
+                    'name' => $this->get_plugin_name( $slug ),
+                ];
+            }
+        }
+
+        // Check if error is in mu-plugins.
+        if ( defined( 'WPMU_PLUGIN_DIR' ) ) {
+            $mu_plugins_dir = wp_normalize_path( WPMU_PLUGIN_DIR );
+            if ( str_starts_with( $file, $mu_plugins_dir . '/' ) ) {
+                $relative = substr( $file, strlen( $mu_plugins_dir ) + 1 );
+                $parts    = explode( '/', $relative );
+                $slug     = $parts[0] ?? '';
+
+                if ( ! empty( $slug ) ) {
+                    return [
+                        'type' => 'mu-plugin',
+                        'slug' => $slug,
+                    ];
+                }
+            }
+        }
+
+        // Check if error is in a theme.
+        if ( function_exists( 'get_theme_root' ) ) {
+            $themes_dir = wp_normalize_path( get_theme_root() );
+            if ( str_starts_with( $file, $themes_dir . '/' ) ) {
+                $relative = substr( $file, strlen( $themes_dir ) + 1 );
+                $parts    = explode( '/', $relative );
+                $slug     = $parts[0] ?? '';
+
+                if ( ! empty( $slug ) ) {
+                    $name = null;
+                    if ( function_exists( 'wp_get_theme' ) ) {
+                        $theme = wp_get_theme( $slug );
+                        $name  = $theme->exists() ? $theme->get( 'Name' ) : null;
+                    }
+                    return [
+                        'type' => 'theme',
+                        'slug' => $slug,
+                        'name' => $name,
+                    ];
+                }
+            }
+        }
+
+        // Check if error is in WordPress core.
+        if ( defined( 'ABSPATH' ) && defined( 'WP_CONTENT_DIR' ) ) {
+            $abspath = wp_normalize_path( ABSPATH );
+            if ( str_starts_with( $file, $abspath ) ) {
+                // Exclude wp-content directory.
+                $wp_content = wp_normalize_path( WP_CONTENT_DIR );
+                if ( ! str_starts_with( $file, $wp_content ) ) {
+                    return [
+                        'type' => 'core',
+                        'slug' => 'wordpress',
+                    ];
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the plugin name from its slug.
+     *
+     * @param string $slug The plugin folder name.
+     *
+     * @return string|null The plugin name or null if not found.
+     */
+    private function get_plugin_name( string $slug ): ?string {
+        // The plugin.php file may not be loadable during early fatal errors.
+        if ( ! defined( 'ABSPATH' ) ) {
+            return null;
+        }
+
+        $plugin_file = ABSPATH . 'wp-admin/includes/plugin.php';
+        if ( ! function_exists( 'get_plugins' ) ) {
+            if ( ! file_exists( $plugin_file ) ) {
+                return null;
+            }
+            require_once $plugin_file;
+        }
+
+        // get_plugins may still not exist if require failed.
+        if ( ! function_exists( 'get_plugins' ) ) {
+            return null;
+        }
+
+        $plugins = get_plugins();
+
+        foreach ( $plugins as $plugin_file => $plugin_data ) {
+            if ( str_starts_with( $plugin_file, $slug . '/' ) || $plugin_file === $slug . '.php' ) {
+                return $plugin_data['Name'] ?? null;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Check if WordPress recovery mode is active.
+     *
+     * @return bool True if recovery mode is active.
+     */
+    private function is_recovery_mode_active(): bool {
+        if ( ! function_exists( 'wp_is_recovery_mode' ) ) {
+            return false;
+        }
+
+        return wp_is_recovery_mode();
+    }
+}
+
+// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- This is a drop-in that must override the global handler.
+$GLOBALS['wp_fatal_error_handler'] = new Lolly_Fatal_Error_Handler();

--- a/src/Lolly/Admin/SettingsPage.php
+++ b/src/Lolly/Admin/SettingsPage.php
@@ -73,9 +73,10 @@ class SettingsPage {
             true
         );
 
-        // Preload the settings endpoint response.
+        // Preload the settings and drop-in endpoint responses.
         $preload_paths = [
             '/lolly/v1/settings',
+            '/lolly/v1/settings/dropin',
         ];
 
         $preload_data = array_reduce(

--- a/src/Lolly/Dropin/DropinManager.php
+++ b/src/Lolly/Dropin/DropinManager.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lolly\Dropin;
+
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Manages the fatal-error-handler.php drop-in file.
+ *
+ * Handles installation, uninstallation, and status checking of the
+ * Lolly fatal error handler drop-in.
+ */
+class DropinManager {
+
+    /**
+     * The drop-in filename.
+     */
+    public const DROPIN_FILENAME = 'fatal-error-handler.php';
+
+    /**
+     * Version header identifier in the drop-in file.
+     */
+    private const VERSION_HEADER = 'Lolly Fatal Error Handler';
+
+    /**
+     * Get the status of the drop-in.
+     *
+     * @return array{installed: bool, is_lolly: bool, version: string|null, writable: bool}|WP_Error
+     */
+    public function get_status(): array|WP_Error {
+        $dropin_path  = $this->get_dropin_path();
+        $is_installed = file_exists( $dropin_path );
+        $is_lolly     = $is_installed && $this->is_ours();
+        $version      = $is_lolly ? $this->get_dropin_version() : null;
+        $is_writable  = $this->is_wp_content_writable();
+
+        return [
+            'installed' => $is_installed,
+            'is_lolly'  => $is_lolly,
+            'version'   => $version,
+            'writable'  => $is_writable,
+        ];
+    }
+
+    /**
+     * Install the drop-in file.
+     *
+     * @return bool|WP_Error True on success, WP_Error on failure.
+     */
+    public function install(): bool|WP_Error {
+        $template_path = $this->get_template_path();
+
+        if ( ! file_exists( $template_path ) ) {
+            return new WP_Error(
+                'lolly_dropin_template_missing',
+                __( 'The drop-in template file is missing from the plugin.', 'lolly' ),
+                [ 'status' => 500 ]
+            );
+        }
+
+        if ( ! $this->is_wp_content_writable() ) {
+            return new WP_Error(
+                'lolly_dropin_not_writable',
+                __( 'The wp-content directory is not writable.', 'lolly' ),
+                [ 'status' => 500 ]
+            );
+        }
+
+        $dropin_path = $this->get_dropin_path();
+
+        // Check if a third-party drop-in exists.
+        if ( file_exists( $dropin_path ) && ! $this->is_ours() ) {
+            return new WP_Error(
+                'lolly_dropin_exists_third_party',
+                __( 'A fatal error handler from another plugin is already installed.', 'lolly' ),
+                [ 'status' => 409 ]
+            );
+        }
+
+        // Copy the template to wp-content.
+        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_copy
+        $copied = copy( $template_path, $dropin_path );
+
+        if ( ! $copied ) {
+            return new WP_Error(
+                'lolly_dropin_copy_failed',
+                __( 'Failed to copy the drop-in file to wp-content.', 'lolly' ),
+                [ 'status' => 500 ]
+            );
+        }
+
+        return true;
+    }
+
+    /**
+     * Uninstall the drop-in file.
+     *
+     * Only removes the drop-in if it belongs to Lolly.
+     *
+     * @return bool|WP_Error True on success, WP_Error on failure.
+     */
+    public function uninstall(): bool|WP_Error {
+        $dropin_path = $this->get_dropin_path();
+
+        if ( ! file_exists( $dropin_path ) ) {
+            // Not installed, nothing to do.
+            return true;
+        }
+
+        if ( ! $this->is_ours() ) {
+            return new WP_Error(
+                'lolly_dropin_exists_third_party',
+                __( 'Cannot uninstall: the drop-in belongs to another plugin.', 'lolly' ),
+                [ 'status' => 409 ]
+            );
+        }
+
+        if ( ! $this->is_wp_content_writable() ) {
+            return new WP_Error(
+                'lolly_dropin_not_writable',
+                __( 'The wp-content directory is not writable.', 'lolly' ),
+                [ 'status' => 500 ]
+            );
+        }
+
+        // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
+        $deleted = unlink( $dropin_path );
+
+        if ( ! $deleted ) {
+            return new WP_Error(
+                'lolly_dropin_delete_failed',
+                __( 'Failed to delete the drop-in file.', 'lolly' ),
+                [ 'status' => 500 ]
+            );
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if the drop-in is installed.
+     *
+     * @return bool
+     */
+    public function is_installed(): bool {
+        return file_exists( $this->get_dropin_path() );
+    }
+
+    /**
+     * Check if the installed drop-in belongs to Lolly.
+     *
+     * @return bool
+     */
+    public function is_ours(): bool {
+        $dropin_path = $this->get_dropin_path();
+
+        if ( ! file_exists( $dropin_path ) ) {
+            return false;
+        }
+
+        $file_data = get_file_data(
+            $dropin_path,
+            [ 'Name' => 'Plugin Name' ]
+        );
+
+        return isset( $file_data['Name'] ) && $file_data['Name'] === self::VERSION_HEADER;
+    }
+
+    /**
+     * Get the version of the installed Lolly drop-in.
+     *
+     * @return string|null The version, or null if not installed or not ours.
+     */
+    public function get_dropin_version(): ?string {
+        $dropin_path = $this->get_dropin_path();
+
+        if ( ! file_exists( $dropin_path ) ) {
+            return null;
+        }
+
+        $file_data = get_file_data(
+            $dropin_path,
+            [ 'Version' => 'Version' ]
+        );
+
+        return isset( $file_data['Version'] ) && $file_data['Version'] !== '' ? $file_data['Version'] : null;
+    }
+
+    /**
+     * Get the path to the drop-in file in wp-content.
+     *
+     * @return string
+     */
+    public function get_dropin_path(): string {
+        return WP_CONTENT_DIR . '/' . self::DROPIN_FILENAME;
+    }
+
+    /**
+     * Get the path to the drop-in template in the plugin.
+     *
+     * @return string
+     */
+    public function get_template_path(): string {
+        return plugin_dir_path( LOLLY_PLUGIN_FILE ) . 'resources/templates/' . self::DROPIN_FILENAME;
+    }
+
+    /**
+     * Check if the wp-content directory is writable.
+     *
+     * @return bool
+     */
+    private function is_wp_content_writable(): bool {
+        return wp_is_writable( WP_CONTENT_DIR );
+    }
+}

--- a/src/Lolly/Listeners/FatalErrorListener.php
+++ b/src/Lolly/Listeners/FatalErrorListener.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lolly\Listeners;
+
+use Lolly\Psr\Log\LoggerInterface;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * FatalErrorListener class.
+ *
+ * Handles logging of fatal PHP errors via shutdown hook.
+ * This provides basic error logging when the drop-in handler is not installed.
+ *
+ * @package Lolly
+ */
+class FatalErrorListener {
+
+    /**
+     * Fatal error types to capture.
+     *
+     * @var int[]
+     */
+    private const FATAL_TYPES = [
+        E_ERROR,
+        E_PARSE,
+        E_CORE_ERROR,
+        E_COMPILE_ERROR,
+        E_USER_ERROR,
+        E_RECOVERABLE_ERROR,
+    ];
+
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    /**
+     * Handle the shutdown event.
+     *
+     * Called via register_shutdown_function. Checks for fatal errors
+     * and logs them if not already handled by the drop-in.
+     */
+    public function on_shutdown(): void {
+        // Check if the drop-in already logged this error.
+        if ( isset( $GLOBALS['lolly_fatal_error_logged'] ) && $GLOBALS['lolly_fatal_error_logged'] === true ) {
+            return;
+        }
+
+        $error = error_get_last();
+
+        if ( $error === null ) {
+            return;
+        }
+
+        if ( ! in_array( $error['type'], self::FATAL_TYPES, true ) ) {
+            return;
+        }
+
+        $this->log_error( $error );
+
+        // Set the flag to prevent duplicate logging if something else checks.
+        $GLOBALS['lolly_fatal_error_logged'] = true;
+    }
+
+    /**
+     * Log the fatal error.
+     *
+     * @param array{type: int, message: string, file: string, line: int} $error Error details from error_get_last().
+     */
+    private function log_error( array $error ): void {
+        $message = sprintf(
+            'PHP Fatal Error: %s in %s on line %d',
+            $error['message'],
+            $error['file'],
+            $error['line']
+        );
+
+        $context = [
+            'error' => [
+                'type'    => $this->get_error_type_name( $error['type'] ),
+                'code'    => $error['type'],
+                'message' => $error['message'],
+                'file'    => $error['file'],
+                'line'    => $error['line'],
+            ],
+        ];
+
+        // Add request context if available.
+        if ( isset( $_SERVER['REQUEST_URI'] ) ) {
+            $context['http'] = [
+                'request' => [
+                    'method' => isset( $_SERVER['REQUEST_METHOD'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) : 'unknown',
+                    // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- URI sanitization would corrupt valid URIs.
+                    'url'    => isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '',
+                ],
+            ];
+        }
+
+        $this->logger->critical( $message, $context );
+    }
+
+    /**
+     * Get the human-readable name for an error type.
+     *
+     * @param int $type The PHP error type constant.
+     *
+     * @return string The error type name.
+     */
+    private function get_error_type_name( int $type ): string {
+        $types = [
+            E_ERROR             => 'E_ERROR',
+            E_PARSE             => 'E_PARSE',
+            E_CORE_ERROR        => 'E_CORE_ERROR',
+            E_COMPILE_ERROR     => 'E_COMPILE_ERROR',
+            E_USER_ERROR        => 'E_USER_ERROR',
+            E_RECOVERABLE_ERROR => 'E_RECOVERABLE_ERROR',
+        ];
+
+        return $types[ $type ] ?? 'UNKNOWN';
+    }
+}

--- a/src/Lolly/Listeners/Provider.php
+++ b/src/Lolly/Listeners/Provider.php
@@ -28,16 +28,19 @@ class Provider extends ServiceProvider {
         HttpListener::class,
         UserListener::class,
         AuthListener::class,
+        FatalErrorListener::class,
     ];
 
     public function register() {
         $this->container->bind( HttpListener::class, HttpListener::class );
         $this->container->bind( UserListener::class, UserListener::class );
         $this->container->bind( AuthListener::class, AuthListener::class );
+        $this->container->bind( FatalErrorListener::class, FatalErrorListener::class );
 
         $this->register_http_listeners();
         $this->register_user_listeners();
         $this->register_auth_listeners();
+        $this->register_fatal_error_listener();
     }
 
     private function register_http_listeners(): void {
@@ -162,5 +165,15 @@ class Provider extends ServiceProvider {
                 2
             );
         }
+    }
+
+    private function register_fatal_error_listener(): void {
+        if ( ! $this->config->is_logging_enabled() ) {
+            return;
+        }
+
+        register_shutdown_function(
+            $this->container->callback( FatalErrorListener::class, 'on_shutdown' )
+        );
     }
 }

--- a/src/Lolly/Plugin/Uninstaller.php
+++ b/src/Lolly/Plugin/Uninstaller.php
@@ -10,6 +10,7 @@ declare( strict_types=1 );
 namespace Lolly\Plugin;
 
 use Lolly\Config\Config;
+use Lolly\Dropin\DropinManager;
 
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
@@ -57,5 +58,17 @@ final class Uninstaller {
      */
     private function handle_uninstall(): void {
         delete_option( Config::OPTION_SLUG );
+        $this->remove_dropin();
+    }
+
+    /**
+     * Remove the drop-in file if it belongs to Lolly.
+     */
+    private function remove_dropin(): void {
+        $dropin_manager = new DropinManager();
+
+        if ( $dropin_manager->is_ours() ) {
+            $dropin_manager->uninstall();
+        }
     }
 }

--- a/src/Lolly/Rest/Provider.php
+++ b/src/Lolly/Rest/Provider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Lolly\Rest;
 
+use Lolly\Dropin\DropinManager;
 use Lolly\lucatume\DI52\ServiceProvider;
 use Lolly\Schema\SchemaLoader;
 
@@ -26,6 +27,7 @@ class Provider extends ServiceProvider {
     public array $provides = [
         SchemaLoader::class,
         SettingsController::class,
+        DropinManager::class,
     ];
 
     /**
@@ -33,6 +35,7 @@ class Provider extends ServiceProvider {
      */
     public function register(): void {
         $this->container->singleton( SchemaLoader::class, SchemaLoader::class );
+        $this->container->singleton( DropinManager::class, DropinManager::class );
         $this->container->singleton( SettingsController::class, SettingsController::class );
 
         add_action( 'rest_api_init', $this->container->callback( SettingsController::class, 'register_routes' ) );

--- a/tests/Stubs/SpyLogger.php
+++ b/tests/Stubs/SpyLogger.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Stubs;
+
+use Lolly\Psr\Log\LoggerInterface;
+
+/**
+ * Spy logger for testing.
+ *
+ * Tracks method calls for assertions in tests.
+ */
+class SpyLogger implements LoggerInterface {
+
+    /**
+     * @var array<int, array{level: string, message: string, context: array<string, mixed>}>
+     */
+    public array $logs = [];
+
+    public function emergency( $message, array $context = [] ): void {
+        $this->log( 'emergency', $message, $context );
+    }
+
+    public function alert( $message, array $context = [] ): void {
+        $this->log( 'alert', $message, $context );
+    }
+
+    public function critical( $message, array $context = [] ): void {
+        $this->log( 'critical', $message, $context );
+    }
+
+    public function error( $message, array $context = [] ): void {
+        $this->log( 'error', $message, $context );
+    }
+
+    public function warning( $message, array $context = [] ): void {
+        $this->log( 'warning', $message, $context );
+    }
+
+    public function notice( $message, array $context = [] ): void {
+        $this->log( 'notice', $message, $context );
+    }
+
+    public function info( $message, array $context = [] ): void {
+        $this->log( 'info', $message, $context );
+    }
+
+    public function debug( $message, array $context = [] ): void {
+        $this->log( 'debug', $message, $context );
+    }
+
+    /**
+     * @param mixed                $level   Log level.
+     * @param mixed                $message Log message.
+     * @param array<string, mixed> $context Log context.
+     */
+    public function log( $level, $message, array $context = [] ): void {
+        $this->logs[] = [
+            'level'   => (string) $level,
+            'message' => (string) $message,
+            'context' => $context,
+        ];
+    }
+
+    /**
+     * Get the count of logs at a specific level.
+     *
+     * @param string $level The log level.
+     *
+     * @return int The count.
+     */
+    public function count_level( string $level ): int {
+        return count(
+            array_filter(
+                $this->logs,
+                fn( $log ) => $log['level'] === $level
+            )
+        );
+    }
+
+    /**
+     * Reset the logs.
+     */
+    public function reset(): void {
+        $this->logs = [];
+    }
+}

--- a/tests/Wpunit/Dropin/DropinManagerTest.php
+++ b/tests/Wpunit/Dropin/DropinManagerTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wpunit\Dropin;
+
+use Lolly\Dropin\DropinManager;
+use lucatume\WPBrowser\TestCase\WPTestCase;
+
+/**
+ * Tests for the DropinManager class.
+ */
+class DropinManagerTest extends WPTestCase {
+
+    private DropinManager $manager;
+
+    public function setUp(): void {
+        parent::setUp();
+
+        $this->manager = new DropinManager();
+
+        // Clean up any existing drop-in before each test.
+        $this->remove_dropin_if_exists();
+    }
+
+    public function tearDown(): void {
+        parent::tearDown();
+
+        // Clean up after each test.
+        $this->remove_dropin_if_exists();
+    }
+
+    private function remove_dropin_if_exists(): void {
+        $path = $this->manager->get_dropin_path();
+        if ( file_exists( $path ) ) {
+            // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
+            unlink( $path );
+        }
+    }
+
+    public function testGetStatusReturnsNotInstalledWhenDropinMissing(): void {
+        $status = $this->manager->get_status();
+
+        $this->assertIsArray( $status );
+        $this->assertFalse( $status['installed'] );
+        $this->assertFalse( $status['is_lolly'] );
+        $this->assertNull( $status['version'] );
+        $this->assertTrue( $status['writable'] );
+    }
+
+    public function testInstallCreatesDropinFile(): void {
+        $result = $this->manager->install();
+
+        $this->assertTrue( $result );
+        $this->assertTrue( file_exists( $this->manager->get_dropin_path() ) );
+    }
+
+    public function testInstallReturnsStatusWithInstalled(): void {
+        $this->manager->install();
+
+        $status = $this->manager->get_status();
+
+        $this->assertTrue( $status['installed'] );
+        $this->assertTrue( $status['is_lolly'] );
+        $this->assertNotNull( $status['version'] );
+    }
+
+    public function testIsOursReturnsTrueForLollyDropin(): void {
+        $this->manager->install();
+
+        $this->assertTrue( $this->manager->is_ours() );
+    }
+
+    public function testIsOursReturnsFalseForThirdPartyDropin(): void {
+        // Create a fake third-party drop-in.
+        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+        file_put_contents(
+            $this->manager->get_dropin_path(),
+            "<?php\n/**\n * Plugin Name: Some Other Plugin\n */"
+        );
+
+        $this->assertFalse( $this->manager->is_ours() );
+    }
+
+    public function testUninstallRemovesDropin(): void {
+        $this->manager->install();
+        $this->assertTrue( file_exists( $this->manager->get_dropin_path() ) );
+
+        $result = $this->manager->uninstall();
+
+        $this->assertTrue( $result );
+        $this->assertFalse( file_exists( $this->manager->get_dropin_path() ) );
+    }
+
+    public function testUninstallReturnsErrorForThirdPartyDropin(): void {
+        // Create a fake third-party drop-in.
+        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+        file_put_contents(
+            $this->manager->get_dropin_path(),
+            "<?php\n/**\n * Plugin Name: Some Other Plugin\n */"
+        );
+
+        $result = $this->manager->uninstall();
+
+        $this->assertInstanceOf( \WP_Error::class, $result );
+        $this->assertEquals( 'lolly_dropin_exists_third_party', $result->get_error_code() );
+    }
+
+    public function testInstallReturnsErrorWhenThirdPartyExists(): void {
+        // Create a fake third-party drop-in.
+        // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+        file_put_contents(
+            $this->manager->get_dropin_path(),
+            "<?php\n/**\n * Plugin Name: Some Other Plugin\n */"
+        );
+
+        $result = $this->manager->install();
+
+        $this->assertInstanceOf( \WP_Error::class, $result );
+        $this->assertEquals( 'lolly_dropin_exists_third_party', $result->get_error_code() );
+    }
+
+    public function testUninstallSucceedsWhenNotInstalled(): void {
+        $this->assertFalse( file_exists( $this->manager->get_dropin_path() ) );
+
+        $result = $this->manager->uninstall();
+
+        $this->assertTrue( $result );
+    }
+
+    public function testCanReinstallDropin(): void {
+        // First install.
+        $this->manager->install();
+        $this->assertTrue( $this->manager->is_installed() );
+
+        // Uninstall.
+        $this->manager->uninstall();
+        $this->assertFalse( $this->manager->is_installed() );
+
+        // Reinstall.
+        $result = $this->manager->install();
+        $this->assertTrue( $result );
+        $this->assertTrue( $this->manager->is_installed() );
+    }
+
+    public function testGetDropinVersionReturnsVersion(): void {
+        $this->manager->install();
+
+        $version = $this->manager->get_dropin_version();
+
+        $this->assertNotNull( $version );
+        $this->assertMatchesRegularExpression( '/^\d+\.\d+\.\d+$/', $version );
+    }
+
+    public function testGetDropinVersionReturnsNullWhenNotInstalled(): void {
+        $version = $this->manager->get_dropin_version();
+
+        $this->assertNull( $version );
+    }
+}

--- a/tests/Wpunit/Listeners/FatalErrorListenerTest.php
+++ b/tests/Wpunit/Listeners/FatalErrorListenerTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Wpunit\Listeners;
+
+use Lolly\Listeners\FatalErrorListener;
+use lucatume\WPBrowser\TestCase\WPTestCase;
+use Tests\Stubs\SpyLogger;
+
+/**
+ * Tests for the FatalErrorListener class.
+ *
+ * Note: Testing fatal error handling is challenging because we can't easily
+ * trigger real fatal errors. These tests focus on the coordination mechanism
+ * between the drop-in and the shutdown hook.
+ */
+class FatalErrorListenerTest extends WPTestCase {
+
+    public function tearDown(): void {
+        parent::tearDown();
+
+        // Reset the global flag.
+        unset( $GLOBALS['lolly_fatal_error_logged'] );
+    }
+
+    public function testOnShutdownSkipsWhenDropinAlreadyLogged(): void {
+        // Simulate that the drop-in has already logged the error.
+        $GLOBALS['lolly_fatal_error_logged'] = true;
+
+        $logger   = new SpyLogger();
+        $listener = new FatalErrorListener( $logger );
+        $listener->on_shutdown();
+
+        // Should not have logged because drop-in already did.
+        $this->assertEquals( 0, $logger->count_level( 'critical' ) );
+    }
+
+    public function testGlobalFlagCoordinatesDropinAndShutdownHook(): void {
+        // Initially the flag should not be set.
+        $this->assertFalse( isset( $GLOBALS['lolly_fatal_error_logged'] ) );
+
+        // After the drop-in logs (simulated), the flag is set.
+        $GLOBALS['lolly_fatal_error_logged'] = true;
+        $this->assertTrue( $GLOBALS['lolly_fatal_error_logged'] );
+
+        // The shutdown hook checks this flag and skips if already logged.
+        // This ensures we don't get duplicate log entries.
+    }
+
+    public function testListenerCanBeInstantiated(): void {
+        $logger   = new SpyLogger();
+        $listener = new FatalErrorListener( $logger );
+
+        $this->assertInstanceOf( FatalErrorListener::class, $listener );
+    }
+}


### PR DESCRIPTION
Adds fatal error logging with two approaches: a shutdown hook that captures
basic error info automatically, and an optional drop-in handler that provides
enhanced logging with backtraces, extension detection, and recovery mode
integration.

The drop-in can be installed via the settings page or REST API. A global flag
coordinates between the drop-in and shutdown hook to prevent duplicate logs.
The drop-in extends WP_Fatal_Error_Handler to preserve WordPress recovery mode.